### PR TITLE
Plot TOF sesans data with wavelength normalisation

### DIFF
--- a/sasmodels/data.py
+++ b/sasmodels/data.py
@@ -439,16 +439,26 @@ def _plot_result_sesans(data, theory, resid, use_data, limits=None):
     num_plots = (use_data or use_theory) + use_resid
 
     if use_data or use_theory:
+        is_tof = np.any(data.lam!=data.lam[0])
         if num_plots > 1:
             plt.subplot(1, num_plots, 1)
         if use_data:
-            plt.errorbar(data.x, data.y, yerr=data.dy)
+            if is_tof:
+                plt.errorbar(data.x, np.log(data.y)/data.lam**2, yerr=data.dy/data.y/data.lam**2)
+            else:
+                plt.errorbar(data.x, data.y, yerr=data.dy)
         if theory is not None:
-            plt.plot(data.x, theory, '-', hold=True)
+            if is_tof:
+                plt.plot(data.x, np.log(theory)/data.lam**2, '-', hold=True)
+            else:
+                plt.plot(data.x, theory, '-', hold=True)
         if limits is not None:
             plt.ylim(*limits)
         plt.xlabel('spin echo length (nm)')
-        plt.ylabel('polarization (P/P0)')
+        if is_tof:
+            plt.ylabel('(Log (P/P$_0$))/$\lambda^2$')
+        else:
+            plt.ylabel('Polarisation (P/P0)')
 
     if resid is not None:
         if num_plots > 1:


### PR DESCRIPTION
The SESANS polarizsation goes as P(Z) = e^(-C(Z) λ²) for wavelength λ and some
C(Z) proporational to our actual signal.  When the wavelength and C(Z)
is close to zero, then the polarisation stands in as a good proxy for
the actual sample.  On time of flight, however, it's necessary to
perform a (log P(Z))/λ² to get a real understanding of the sample.

This patch checks to see whether a data set is time of flight (by check
to see if the wavelengths are all equal) and then changes the default
plotting method to use the log over lambda square plots for time of
flight data and raw polarisation for reactor data.