### PR TITLE
import was causing problems... race condition?

### DIFF
--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -784,7 +784,7 @@ def make_model_info(kernel_module):
         name = " ".join(w.capitalize() for w in kernel_id.split('_'))
     model_info = dict(
         id=kernel_id,  # string used to load the kernel
-        filename=abspath(kernel_module.__file__),
+        filename=abspath(kernel_module.__file__.rstrip("cd")),
         name=name,
         title=kernel_module.title,
         description=kernel_module.description,


### PR DESCRIPTION
seems like the import in sasmodels/custom/__init__.py from one thread would create a .pyc file, which would get picked up by the import in another thread before it was deleted as part of the load_module_from_path function.  Then the name in __file__ was ...pyc which no longer existed, and checking the mtime of that never made sense anyway.  So check the mtime of the source .py file instead for custom modules