### PR TITLE
no ticket: allow sascomp with with q,dq from data file

### DIFF
--- a/sasmodels/data.py
+++ b/sasmodels/data.py
@@ -53,6 +53,10 @@ def load_data(filename):
     data = loader.load(filename)
     if data is None:
         raise IOError("Data %r could not be loaded" % filename)
+    if hasattr(data, 'x'):
+        data.qmin, data.qmax = data.x.min(), data.x.max()
+        data.mask = (np.isnan(data.y) if data.y is not None
+                     else np.zeros_like(data.x, dtype='bool'))
     return data
 
 
@@ -347,7 +351,7 @@ def plot_data(data, view='log', limits=None):
     # Note: kind of weird using the plot result functions to plot just the
     # data, but they already handle the masking and graph markup already, so
     # do not repeat.
-    if hasattr(data, 'lam'):
+    if hasattr(data, 'isSesans') and data.isSesans:
         _plot_result_sesans(data, None, None, use_data=True, limits=limits)
     elif hasattr(data, 'qx_data'):
         _plot_result2D(data, None, None, view, use_data=True, limits=limits)
@@ -375,7 +379,7 @@ def plot_theory(data, theory, resid=None, view='log',
 
     *Iq_calc* is the raw theory values without resolution smearing
     """
-    if hasattr(data, 'lam'):
+    if hasattr(data, 'isSesans') and data.isSesans:
         _plot_result_sesans(data, theory, resid, use_data=True, limits=limits)
     elif hasattr(data, 'qx_data'):
         _plot_result2D(data, theory, resid, view, use_data, limits=limits)

--- a/sasmodels/direct_model.py
+++ b/sasmodels/direct_model.py
@@ -191,7 +191,7 @@ class DataMixin(object):
         self._model = model
 
         # interpret data
-        if hasattr(data, 'lam'):
+        if hasattr(data, 'isSesans') and data.isSesans:
             self.data_type = 'sesans'
         elif hasattr(data, 'qx_data'):
             self.data_type = 'Iqxy'


### PR DESCRIPTION
Extend sascomp with a -data=filename parameter so that we can test models directly against a particular q value.  This is faster than going through the sasview gui for debugging models, and makes it easier to add debug info to the model calculation.  Also, errors are less likely to be eaten by the GUI and the traceback shows more information.

Although it is harmless, we should wait until after the next release before applying this patch.
