### PR TITLE
ENH: travis on py3 and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,66 @@
 language: python
-python:
-- '2.7'
+
+sudo:  false
+
+matrix:
+  include:
+    - os: linux
+      env:
+        - PY=2.7
+        - NUMPYSPEC=numpy
+    - os: linux
+      env:
+        - PY=3
+        - NUMPYSPEC=numpy
+    - os: osx
+      language: generic
+      env:
+        - PY=2.7
+        - NUMPYSPEC=numpy
+    - os: osx
+      language: generic
+      env:
+        - PY=3
+        - NUMPYSPEC=numpy
+
+# whitelist
 branches:
   only:
-  - master
-virtualenv:
-  system_site_packages: true
+    - master
+
+addons:
+  apt:
+    packages:
+      opencl-headers
+
 before_install:
-- sudo apt-get update;
-- sudo apt-get install python-numpy python-scipy
+  - echo $TRAVIS_OS_NAME
+
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi;
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+    fi;
+
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda update --yes conda
+
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  - conda install --yes python=$PY $NUMPYSPEC scipy cython mako cffi
+
 install:
-- pip install bumps
-- pip install unittest-xml-reporting
+  - pip install bumps
+  - pip install unittest-xml-reporting
+
 script:
 - export WORKSPACE=/home/travis/build/SasView/sasmodels/
 - python -m sasmodels.model_test dll all
+
 notifications:
   slack:
     secure: xNAUeSu1/it/x9Q2CSg79aw1LLc7d6mLpcqSCTeKROp71RhkFf8VjJnJm/lEbKHNC8yj5H9UHrz5DmzwJzI+6oMt4NdEeS6WvGhwGY/wCt2IcJKxw0vj1DAU04qFMS041Khwclo6jIqm76DloinXvmvsS+K/nSyQkF7q4egSlwA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,10 @@ before_install:
 
   - conda install --yes python=$PY $NUMPYSPEC scipy cython mako cffi
 
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      pip install pyopencl;
+    fi;
+
 install:
   - pip install bumps
   - pip install unittest-xml-reporting


### PR DESCRIPTION
This PR allows travis to test for Python 2.7 & 3 on Linux and OSX.
However, I cannot for the life of me figure out how to get pyopencl installed and working on Linux. It's possible on OSX.