### PR TITLE
Ticket 754

### DIFF
--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -46,7 +46,11 @@ from __future__ import print_function
 
 import sys
 import unittest
-from StringIO import StringIO
+
+try:
+    from StringIO import StringIO
+except ImportError: # StringIO.StringIO renamed to io.StringIO in Python 3
+    from io import StringIO
 
 import numpy as np  # type: ignore
 

--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -46,6 +46,7 @@ from __future__ import print_function
 
 import sys
 import unittest
+from StringIO import StringIO
 
 import numpy as np  # type: ignore
 
@@ -349,7 +350,7 @@ def run_one(model):
     from unittest.runner import TextTestResult, _WritelnDecorator
 
     # Build a object to capture and print the test results
-    stream = _WritelnDecorator(sys.stdout)  # Add writeln() method to stream
+    stream = _WritelnDecorator(StringIO())  # Add writeln() method to stream
     verbosity = 2
     descriptions = True
     result = TextTestResult(stream, descriptions, verbosity)
@@ -387,6 +388,10 @@ def run_one(model):
         break
     else:
         stream.writeln("Note: no test suite created --- this should never happen")
+
+    output = stream.getvalue()
+    stream.close()
+    return output
 
 
 def main(*models):


### PR DESCRIPTION
Make `sasmodels.model_test.run_one` return the output of running the unit tests as a string. This is required for [ticket #754](http://trac.sasview.org/ticket/754) (5), and is implemented as detailed in the comments.

See [sasview pull request #96](https://github.com/SasView/sasview/pull/96)