### PR TITLE
Ticket 767

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
-eval "$(ssh-agent -s)"
-chmod 600 .travis/travis_rsa
-ssh-add .travis/travis_rsa
-git remote add deploy git@danse.chem.utk.edu:/home/git/sasmodels
-git push deploy master
+if [[ $encrypted_cb04388797b6_iv ]]
+then
+    eval "$(ssh-agent -s)"
+    chmod 600 .travis/travis_rsa
+    ssh-add .travis/travis_rsa
+    git remote add deploy git@danse.chem.utk.edu:/home/git/sasmodels
+    git push deploy master
+fi

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -87,6 +87,7 @@ Options (* for default):
     -cutoff=1e-5* cutoff value for including a point in polydispersity
     -magnetic/-nonmagnetic* suppress magnetism
     -accuracy=Low accuracy of the resolution calculation Low, Mid, High, Xhigh
+    -neval=1 sets the number of evals for more accurate timing
 
     === precision options ===
     -calc=default uses the default calcution precision
@@ -1012,12 +1013,12 @@ OPTIONS = [
     'poly', 'mono', 'cutoff=',
     'magnetic', 'nonmagnetic',
     'accuracy=',
+    'neval=',  # for timing...
 
     # Precision options
     'calc=',
     'half', 'fast', 'single', 'double', 'single!', 'double!', 'quad!',
     'sasview',  # TODO: remove sasview 3.x support
-    'timing=',
 
     # Output options
     'help', 'html', 'edit',
@@ -1067,7 +1068,7 @@ def get_pars(model_info, use_demo=False):
                 pars[p.id + ext] = val
 
     # Plug in values given in demo
-    if use_demo:
+    if use_demo and model_info.demo:
         pars.update(model_info.demo)
     return pars
 

--- a/sasmodels/mixture.py
+++ b/sasmodels/mixture.py
@@ -24,29 +24,89 @@ try:
 except ImportError:
     pass
 
-def make_mixture_info(parts):
+def make_mixture_info(parts, operation='+'):
     # type: (List[ModelInfo]) -> ModelInfo
     """
     Create info block for mixture model.
     """
-    flatten = []
-    for part in parts:
-        if part.composition and part.composition[0] == 'mixture':
-            flatten.extend(part.composition[1])
-        else:
-            flatten.append(part)
-    parts = flatten
-
     # Build new parameter list
     combined_pars = []
-    for k, part in enumerate(parts):
+
+    model_num = 0
+    all_parts = copy(parts)
+    is_flat = False
+    while not is_flat:
+        is_flat = True
+        for part in all_parts:
+            if part.composition and part.composition[0] == 'mixture' and \
+                len(part.composition[1]) > 1:
+                all_parts += part.composition[1]
+                all_parts.remove(part)
+                is_flat = False
+
+    # When creating a mixture model that is a sum of product models (ie (1*2)+(3*4))
+    # the parameters for models 1 & 2 will be prefixed with A & B respectively,
+    # but so will the parameters for models 3 & 4. We need to rename models 3 & 4
+    # so that they are prefixed with C & D to avoid overlap of parameter names.
+    used_prefixes = []
+    for part in parts:
+        i = 0
+        if part.composition and part.composition[0] == 'mixture':
+            npars_list = [info.parameters.npars for info in part.composition[1]]
+            for npars in npars_list:
+                # List of params of one of the constituent models of part
+                submodel_pars = part.parameters.kernel_parameters[i:i+npars]
+                # Prefix of the constituent model
+                prefix = submodel_pars[0].name[0]
+                if prefix not in used_prefixes: # Haven't seen this prefix so far
+                    used_prefixes.append(prefix)
+                    i += npars
+                    continue
+                while prefix in used_prefixes:
+                    # This prefix has been already used, so change it to the
+                    # next letter that hasn't been used
+                    prefix = chr(ord(prefix) + 1)
+                used_prefixes.append(prefix)
+                prefix += "_"
+                # Update the parameters of this constituent model to use the
+                # new prefix
+                for par in submodel_pars:
+                    par.id = prefix + par.id[2:]
+                    par.name = prefix + par.name[2:]
+                    if par.length_control is not None:
+                        par.length_control = prefix + par.length_control[2:]
+                i += npars
+
+    for part in parts:
         # Parameter prefix per model, A_, B_, ...
         # Note that prefix must also be applied to id and length_control
         # to support vector parameters
-        prefix = chr(ord('A')+k) + '_'
-        scale =  Parameter(prefix+'scale', default=1.0,
-                           description="model intensity for " + part.name)
-        combined_pars.append(scale)
+        prefix = ''
+        if not part.composition:
+            # Model isn't a composition model, so it's parameters don't have a
+            # a prefix. Add the next available prefix
+            prefix = chr(ord('A')+len(used_prefixes))
+            used_prefixes.append(prefix)
+            prefix += '_'
+            
+        if operation == '+':
+            # If model is a sum model, each constituent model gets its own scale parameter
+            scale_prefix = prefix
+            if prefix == '' and part.operation == '*':
+                # `part` is a composition product model. Find the prefixes of
+                # it's parameters to form a new prefix for the scale, eg:
+                # a model with A*B*C will have ABC_scale
+                sub_prefixes = []
+                for param in part.parameters.kernel_parameters:
+                    # Prefix of constituent model
+                    sub_prefix = param.id.split('_')[0]
+                    if sub_prefix not in sub_prefixes:
+                        sub_prefixes.append(sub_prefix)
+                # Concatenate sub_prefixes to form prefix for the scale
+                scale_prefix = ''.join(sub_prefixes) + '_'
+            scale =  Parameter(scale_prefix + 'scale', default=1.0,
+                            description="model intensity for " + part.name)
+            combined_pars.append(scale)
         for p in part.parameters.kernel_parameters:
             p = copy(p)
             p.name = prefix + p.name
@@ -66,8 +126,9 @@ def make_mixture_info(parts):
         return combined_pars
 
     model_info = ModelInfo()
-    model_info.id = '+'.join(part.id for part in parts)
-    model_info.name = ' + '.join(part.name for part in parts)
+    model_info.id = operation.join(part.id for part in parts)
+    model_info.operation = operation
+    model_info.name = '(' + operation.join(part.name for part in parts) + ')'
     model_info.filename = None
     model_info.title = 'Mixture model with ' + model_info.name
     model_info.description = model_info.title
@@ -120,6 +181,7 @@ class MixtureKernel(Kernel):
         self.info =  model_info
         self.kernels = kernels
         self.dtype = self.kernels[0].dtype
+        self.operation = model_info.operation
         self.results = []  # type: List[np.ndarray]
 
     def __call__(self, call_details, values, cutoff, magnetic):
@@ -128,13 +190,19 @@ class MixtureKernel(Kernel):
         total = 0.0
         # remember the parts for plotting later
         self.results = []  # type: List[np.ndarray]
-        offset = 2 # skip scale & background
         parts = MixtureParts(self.info, self.kernels, call_details, values)
         for kernel, kernel_details, kernel_values in parts:
             #print("calling kernel", kernel.info.name)
             result = kernel(kernel_details, kernel_values, cutoff, magnetic)
-            #print(kernel.info.name, result)
-            total += result
+            result = np.array(result).astype(kernel.dtype)
+            # print(kernel.info.name, result)
+            if self.operation == '+':
+                total += result
+            elif self.operation == '*':
+                if np.all(total) == 0.0:
+                    total = result
+                else:
+                    total *= result
             self.results.append(result)
 
         return scale*total + background
@@ -175,7 +243,9 @@ class MixtureParts(object):
         #call_details.show(values)
 
         self.part_num += 1
-        self.par_index += info.parameters.npars + 1
+        self.par_index += info.parameters.npars
+        if self.model_info.operation == '+':
+            self.par_index += 1 # Account for each constituent model's scale param
         self.mag_index += 3 * len(info.parameters.magnetism_index)
 
         return kernel, call_details, values
@@ -186,11 +256,12 @@ class MixtureParts(object):
         # par_index is index into values array of the current parameter,
         # which includes the initial scale and background parameters.
         # We want the index into the weight length/offset for each parameter.
-        # Exclude the initial scale and background, so subtract two, but each
-        # component has its own scale factor which we need to skip when
-        # constructing the details for the kernel, so add one, giving a
-        # net subtract one.
-        index = slice(par_index - 1, par_index - 1 + info.parameters.npars)
+        # Exclude the initial scale and background, so subtract two. If we're
+        # building an addition model, each component has its own scale factor
+        # which we need to skip when constructing the details for the kernel, so
+        # add one, giving a net subtract one.
+        diff = 1 if self.model_info.operation == '+' else 2
+        index = slice(par_index - diff, par_index - diff + info.parameters.npars)
         length = full.length[index]
         offset = full.offset[index]
         # The complete weight vector is being sent to each part so that
@@ -200,9 +271,10 @@ class MixtureParts(object):
 
     def _part_values(self, info, par_index, mag_index):
         # type: (ModelInfo, int, int) -> np.ndarray
-        #print(info.name, par_index, self.values[par_index:par_index + info.parameters.npars + 1])
-        scale = self.values[par_index]
-        pars = self.values[par_index + 1:par_index + info.parameters.npars + 1]
+        # Set each constituent model's scale to 1 if this is a multiplication model
+        scale = self.values[par_index] if self.model_info.operation == '+' else 1.0
+        diff = 1 if self.model_info.operation == '+' else 0 # Skip scale if addition model
+        pars = self.values[par_index + diff:par_index + info.parameters.npars + diff]
         nmagnetic = len(info.parameters.magnetism_index)
         if nmagnetic:
             spin_state = self.values[self.spin_index:self.spin_index + 3]

--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -200,8 +200,9 @@ def _hide_model_case_from_nose():
                 ({}, 'ER', None),
                 ({}, 'VR', None),
                 ]
-
-            tests = smoke_tests + self.info.tests
+            tests = smoke_tests
+            if self.info.tests is not None:
+                tests += self.info.tests
             try:
                 model = build_model(self.info, dtype=self.dtype,
                                     platform=self.platform)
@@ -370,7 +371,6 @@ def run_one(model):
         import traceback
         stream.writeln(traceback.format_exc())
         return
-
     # Run the test suite
     suite.run(result)
 

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -726,6 +726,9 @@ def make_model_info(kernel_module):
     Note: vectorized Iq and Iqxy functions will be created for python
     models when the model is first called, not when the model is loaded.
     """
+    if hasattr(kernel_module, "model_info"):
+        # Custom sum/multi models
+        return kernel_module.model_info
     info = ModelInfo()
     #print("make parameter table", kernel_module.parameters)
     parameters = make_parameter_table(getattr(kernel_module, 'parameters', []))

--- a/sasmodels/models/spherical_sld.py
+++ b/sasmodels/models/spherical_sld.py
@@ -17,11 +17,11 @@ interface. The form factor is normalized by the total volume of the sphere.
 
 Interface shapes are as follows::
 
-    0: erf(|nu|*z)
-    1: Rpow(z^|nu|)
-    2: Lpow(z^|nu|)
-    3: Rexp(-|nu|z)
-    4: Lexp(-|nu|z)
+    0: erf($\nu z$)
+    1: Rpow($z^\nu$)
+    2: Lpow($z^\nu$)
+    3: Rexp($-\nu z$)
+    4: Lexp($-\nu z$)
 
 Definition
 ----------

--- a/sasmodels/product.py
+++ b/sasmodels/product.py
@@ -67,13 +67,17 @@ def make_product_info(p_info, s_info):
 
     translate_name = dict((old.id, new.id) for old, new
                           in zip(s_pars.kernel_parameters[1:], s_list))
-    demo = {}
-    demo.update(p_info.demo.items())
-    demo.update((translate_name[k], v) for k, v in s_info.demo.items()
-                if k not in ("background", "scale") and not k.startswith(ER_ID))
     combined_pars = p_pars.kernel_parameters + s_list
     parameters = ParameterTable(combined_pars)
     parameters.max_pd = p_pars.max_pd + s_pars.max_pd
+    def random():
+        combined_pars = p_info.random()
+        s_names = set(par.id for par in s_pars.kernel_parameters[1:])
+        s = s_info.random()
+        combined_pars.update((translate_name[k], v)
+                    for k, v in s_info.random().items()
+                    if k in s_names)
+        return combined_pars
 
     model_info = ModelInfo()
     model_info.id = '*'.join((p_id, s_id))
@@ -84,6 +88,7 @@ def make_product_info(p_info, s_info):
     model_info.docs = model_info.title
     model_info.category = "custom"
     model_info.parameters = parameters
+    model_info.random = random
     #model_info.single = p_info.single and s_info.single
     model_info.structure_factor = False
     model_info.variant_info = None
@@ -94,12 +99,11 @@ def make_product_info(p_info, s_info):
     model_info.composition = ('product', [p_info, s_info])
     # TODO: delegate random to p_info, s_info
     #model_info.random = lambda: {}
-    model_info.demo = demo
 
-    ## Show the parameter table with the demo values
+    ## Show the parameter table
     #from .compare import get_pars, parlist
     #print("==== %s ====="%model_info.name)
-    #values = get_pars(model_info, use_demo=True)
+    #values = get_pars(model_info)
     #print(parlist(model_info, values, is2d=True))
     return model_info
 
@@ -125,6 +129,7 @@ class ProductModel(KernelModel):
         self.info = model_info
         self.P = P
         self.S = S
+        self.dtype = P.dtype
 
     def make_kernel(self, q_vectors):
         # type: (List[np.ndarray]) -> Kernel

--- a/sasmodels/product.py
+++ b/sasmodels/product.py
@@ -80,8 +80,8 @@ def make_product_info(p_info, s_info):
         return combined_pars
 
     model_info = ModelInfo()
-    model_info.id = '*'.join((p_id, s_id))
-    model_info.name = '*'.join((p_name, s_name))
+    model_info.id = '@'.join((p_id, s_id))
+    model_info.name = '@'.join((p_name, s_name))
     model_info.filename = None
     model_info.title = 'Product of %s and %s'%(p_name, s_name)
     model_info.description = model_info.title


### PR DESCRIPTION
I've edited MixtureModel to allow the addition as well as multiplication of models, since ProductModel is very specific to P(Q)*S(Q) models, and a user may want to multiply models that aren't necessarily one form factor model and one structure factor.

If MixtureModel is doing multiplication, it wont't add a scale parameter to each constituent model (see ticket [#767](http://trac.sasview.org/ticket/767))

See sasview pull request [#100](https://github.com/SasView/sasview/pull/100)