### PR TITLE
Ticket 1006

### DIFF
--- a/sasmodels/product.py
+++ b/sasmodels/product.py
@@ -99,6 +99,7 @@ def make_product_info(p_info, s_info):
     # Iq, Iqxy, form_volume, ER, VR and sesans
     # Remember the component info blocks so we can build the model
     model_info.composition = ('product', [p_info, s_info])
+    model_info.control = p_info.control
     # TODO: delegate random to p_info, s_info
     #model_info.random = lambda: {}
 

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -204,13 +204,7 @@ def MultiplicationModel(form_factor, structure_factor):
     model_info = product.make_product_info(form_factor._model_info,
                                            structure_factor._model_info)
     ConstructedModel = make_model_from_info(model_info)
-    if form_factor.is_multiplicity_model:
-        ConstructedModel.is_multiplicity_model = True
-        ConstructedModel.multiplicity_info = form_factor.multiplicity_info
-        ConstructedModel.non_fittable = form_factor.non_fittable
-        return ConstructedModel(form_factor.multiplicity)
-    else:
-        return ConstructedModel()
+    return ConstructedModel(form_factor.multiplicity)    
 
 
 def _generate_model_attributes(model_info):
@@ -328,7 +322,7 @@ class SasviewModel(object):
     is_form_factor = False
     #: True if model has multiplicity
     is_multiplicity_model = False
-    #: Mulitplicity information
+    #: Multiplicity information
     multiplicity_info = None # type: MultiplicityInfoType
 
     # Per-instance variables
@@ -359,7 +353,7 @@ class SasviewModel(object):
         # we provide some sort of data description including title, labels
         # and lines to plot.
 
-        # Get the list of hidden parameters given the mulitplicity
+        # Get the list of hidden parameters given the multiplicity
         # Don't include multiplicity in the list of parameters
         self.multiplicity = multiplicity
         if multiplicity is not None:

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -204,6 +204,13 @@ def MultiplicationModel(form_factor, structure_factor):
     model_info = product.make_product_info(form_factor._model_info,
                                            structure_factor._model_info)
     ConstructedModel = make_model_from_info(model_info)
+    if form_factor.is_multiplicity_model:
+        ConstructedModel.is_multiplicity_model = True
+        ConstructedModel.multiplicity_info = form_factor.multiplicity_info
+        ConstructedModel.non_fittable = form_factor.non_fittable
+        return ConstructedModel(form_factor.multiplicity)
+    else:
+        return ConstructedModel()
     return ConstructedModel()
 
 

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -211,7 +211,6 @@ def MultiplicationModel(form_factor, structure_factor):
         return ConstructedModel(form_factor.multiplicity)
     else:
         return ConstructedModel()
-    return ConstructedModel()
 
 
 def _generate_model_attributes(model_info):


### PR DESCRIPTION
The problem in the interface when combining a form factor that has multiplicity with a structure factor was due to the fact that the MultiplicationModel function did not propagate to the new model the information about the multiplicity and the non_fittable (n) parameters. With these changes, my test with the core_multi_shell model x the hard sphere S(Q) works well. But probably Paul K should check if there are some other attributes that need to be passed or if this should be done in a different way. 