### PR TITLE
use Iqac/Iqabc for the new orientation interface but Iqxy for the old

### DIFF
--- a/doc/guide/orientation/orientation.rst
+++ b/doc/guide/orientation/orientation.rst
@@ -85,7 +85,7 @@ in the reverse order, so
 
 
 The $\theta$ and $\phi$ orientation parameters for the cylinder only appear
-when fitting 2d data. On introducing "Orientation Distribution" in the
+when fitting 2d data. On introducing "Orientational Distribution" in the
 angles, "distribution of theta" and "distribution of phi" parameters will
 appear. These are actually rotations about the axes $\delta_1$ and $\delta_2$
 of the cylinder, which correspond to the $b$ and $a$ axes of the cylinder
@@ -118,13 +118,13 @@ scale factor of $\sin(\Delta\theta)$ that applies to each point in the
 integral. This is not enough, though. Consider a shape which is tumbling
 freely around the $b$ axis, with $\Delta\theta$ uniform in $[-180, 180]$. At
 $\pm 90$, all points in $\Delta\phi$ map to the pole, so the jitter will have
-a distinct angular preference. If the spin axis is normal to the beam (which
-will be the case for $\theta=90$ and $\Psi=90$), the scattering pattern
-should be circularly symmetric, but it will go to zero at $\pm 90$ due to the
+a distinct angular preference. If the spin axis is along the beam (which
+will be the case for $\theta=90$ and $\Psi=90$) the scattering pattern
+should be circularly symmetric, but it will go to zero at $q_x = 0$ due to the
 $\sin(\Delta\theta)$ correction. This problem does not appear for a shape
 that is tumbling freely around the $a$ axis, with $\Delta\phi$ uniform in
 $[-180, 180]$, so swap the $a$ and $b$ axes so $\Delta\theta < \Delta\phi$
-and adjust $\Psi$ by 90. This works with the existing sasmodels shapes due to
+and adjust $\Psi$ by 90. This works with the current sasmodels shapes due to
 symmetry.
 
 Alternative projections were considered.
@@ -144,10 +144,10 @@ is like the azimuthal equidistance projection, but it preserves area instead
 of distance. It also has the same behaviour for $\Delta\theta$ and $\Delta\phi$.
 The `Guyou projection <https://en.wikipedia.org/wiki/Guyou_hemisphere-in-a-square_projection>`_
 has an excellent balance with reasonable distortion in both $\Delta\theta$
-and $\Delta\phi$, as well as preserving small patches. However, it is
-considerably more overhead, and we have not yet derived the formula for the
-distortion correction, measuring the degree of stretch at the point
-$(\Delta\theta, \Delta\phi)$ on the map.
+and $\Delta\phi$, as well as preserving small patches. However, it requires
+considerably more computational overhead, and we have not yet derived the
+formula for the distortion correction, measuring the degree of stretch at
+the point $(\Delta\theta, \Delta\phi)$ on the map.
 
 .. note::
     Note that the form factors for oriented particles are performing

--- a/doc/guide/orientation/orientation.rst
+++ b/doc/guide/orientation/orientation.rst
@@ -110,32 +110,35 @@ but the orientation is defined over a sphere, we are left with a
 problem, with different tradeoffs depending on how values in $\Delta\theta$
 and $\Delta\phi$ are translated into latitude/longitude on the sphere.
 
-Sasmodels is using the *equirectangular* projection. In this projection,
-square patches in angular dispersity become wedge-shaped patches on the
-sphere. To correct for the changing point density, there is a scale factor of
-$\sin(\Delta\theta)$ that applies to each point in the integral. This is not
-enough, though. Consider a shape which is tumbling freely around the $b$
-axis, with $\Delta\theta$ uniform in $[-180, 180]$. At $\pm 90$, all points
-in $\Delta\phi$ map to the pole, so the jitter will have a
-distinct angular preference. If the spin axis is normal to the beam
-(which will be the case for $\theta=90$ and $\Psi=90$), the scattering
-pattern should be circularly symmetric, but it will go to zero at $\pm 90$ due
-to the $\sin(\Delta\theta)$ correction. This problem does not appear for a shape
+Sasmodels is using the
+`equirectangular projection <https://en.wikipedia.org/wiki/Equirectangular_projection>`_.
+In this projection, square patches in angular dispersity become wedge-shaped
+patches on the sphere. To correct for the changing point density, there is a
+scale factor of $\sin(\Delta\theta)$ that applies to each point in the
+integral. This is not enough, though. Consider a shape which is tumbling
+freely around the $b$ axis, with $\Delta\theta$ uniform in $[-180, 180]$. At
+$\pm 90$, all points in $\Delta\phi$ map to the pole, so the jitter will have
+a distinct angular preference. If the spin axis is normal to the beam (which
+will be the case for $\theta=90$ and $\Psi=90$), the scattering pattern
+should be circularly symmetric, but it will go to zero at $\pm 90$ due to the
+$\sin(\Delta\theta)$ correction. This problem does not appear for a shape
 that is tumbling freely around the $a$ axis, with $\Delta\phi$ uniform in
 $[-180, 180]$, so swap the $a$ and $b$ axes so $\Delta\theta < \Delta\phi$
-and adjust $\Psi$ by 90. This works with the existing sasmodels shapes
-due to symmetry.
+and adjust $\Psi$ by 90. This works with the existing sasmodels shapes due to
+symmetry.
 
-There are alternative projections. The *sinusoidal* projection works by
-scaling $\Delta\phi$ as $\Delta\theta$ increases, and dropping those points
-outside $[-180, 180]$. The distortions are a little less for middle ranges of
-$\Delta\theta$, but they are still severe for large $\Delta\theta$ and the
-model is much harder to explain. The *Guyou* projection has an excellent
-balance with reasonable distortion in both $\Delta\theta$ and $\Delta\phi$,
-as well as preserving small patches. However, it is considerably more
-expensive to implement, and we have not yet computed the distortion
-correction, measuring the degree of stretch at the
-point $(\Delta\theta, \Delta\phi)$ in the correction.
+There are alternative projections. The
+`sinusoidal projection <https://en.wikipedia.org/wiki/Sinusoidal_projection>`_
+works by scaling $\Delta\phi$ as $\Delta\theta$ increases, and dropping those
+points outside $[-180, 180]$. The distortions are a little less for middle
+ranges of $\Delta\theta$, but they are still severe for large $\Delta\theta$
+and the model is much harder to explain. The
+`Guyou projection <https://en.wikipedia.org/wiki/Guyou_hemisphere-in-a-square_projection>`_
+has an excellent balance with reasonable distortion in both $\Delta\theta$
+and $\Delta\phi$, as well as preserving small patches. However, it is
+considerably more expensive to implement, and we have not yet computed the
+distortion correction, measuring the degree of stretch at the point
+$(\Delta\theta, \Delta\phi)$ in the correction.
 
 .. note::
     Note that the form factors for oriented particles are performing

--- a/doc/guide/orientation/orientation.rst
+++ b/doc/guide/orientation/orientation.rst
@@ -127,18 +127,27 @@ $[-180, 180]$, so swap the $a$ and $b$ axes so $\Delta\theta < \Delta\phi$
 and adjust $\Psi$ by 90. This works with the existing sasmodels shapes due to
 symmetry.
 
-There are alternative projections. The
-`sinusoidal projection <https://en.wikipedia.org/wiki/Sinusoidal_projection>`_
+Alternative projections were considered.
+The `sinusoidal projection <https://en.wikipedia.org/wiki/Sinusoidal_projection>`_
 works by scaling $\Delta\phi$ as $\Delta\theta$ increases, and dropping those
 points outside $[-180, 180]$. The distortions are a little less for middle
 ranges of $\Delta\theta$, but they are still severe for large $\Delta\theta$
-and the model is much harder to explain. The
-`Guyou projection <https://en.wikipedia.org/wiki/Guyou_hemisphere-in-a-square_projection>`_
+and the model is much harder to explain.
+The `azimuthal equidistance projection <https://en.wikipedia.org/wiki/Azimuthal_equidistant_projection>`_
+also improves on the equirectangular projection by extending the range of
+reasonable values for the $\Delta\theta$ range, with $\Delta\phi$ forming a
+wedge that cuts to the opposite side of the sphere rather than cutting to the
+pole. This projection has the nice property that distance from the center are
+preserved, and that $\Delta\theta$ and $\Delta\phi$ act the same.
+The `azimuthal equal area projection <https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection>`_
+is like the azimuthal equidistance projection, but it preserves area instead
+of distance. It also has the same behaviour for $\Delta\theta$ and $\Delta\phi$.
+The `Guyou projection <https://en.wikipedia.org/wiki/Guyou_hemisphere-in-a-square_projection>`_
 has an excellent balance with reasonable distortion in both $\Delta\theta$
 and $\Delta\phi$, as well as preserving small patches. However, it is
-considerably more expensive to implement, and we have not yet computed the
+considerably more overhead, and we have not yet derived the formula for the
 distortion correction, measuring the degree of stretch at the point
-$(\Delta\theta, \Delta\phi)$ in the correction.
+$(\Delta\theta, \Delta\phi)$ on the map.
 
 .. note::
     Note that the form factors for oriented particles are performing

--- a/doc/guide/orientation/orientation.rst
+++ b/doc/guide/orientation/orientation.rst
@@ -3,18 +3,23 @@
 Oriented particles
 ==================
 
-With two dimensional small angle diffraction data SasView will calculate
+With two dimensional small angle diffraction data sasmodels will calculate
 scattering from oriented particles, applicable for example to shear flow
 or orientation in a magnetic field.
 
 In general we first need to define the reference orientation
-of the particles with respect to the incoming neutron or X-ray beam. This
-is done using three angles: $\theta$ and $\phi$ define the orientation of
-the axis of the particle, angle $\Psi$ is defined as the orientation of
-the major axis of the particle cross section with respect to its starting
-position along the beam direction. The figures below are for an elliptical
-cross section cylinder, but may be applied analogously to other shapes of
-particle.
+of the particle's $a$-$b$-$c$ axes with respect to the incoming
+neutron or X-ray beam. This is done using three angles: $\theta$ and $\phi$
+define the orientation of the $c$-axis of the particle, and angle $\Psi$ is
+defined as the orientation of the major axis of the particle cross section
+with respect to its starting position along the beam direction (or
+equivalently, as rotation about the $c$ axis). There is an unavoidable
+ambiguity when $c$ is aligned with $z$ in that $\phi$ and $\Psi$ both
+serve to rotate the particle about $c$, but this symmetry is destroyed
+when $\theta$ is not a multiple of 180.
+
+The figures below are for an elliptical cross section cylinder, but may
+be applied analogously to other shapes of particle.
 
 .. note::
     It is very important to note that these angles, in particular $\theta$
@@ -28,10 +33,10 @@ particle.
     orient_img/elliptical_cylinder_angle_definition.png
 
     Definition of angles for oriented elliptical cylinder, where axis_ratio
-    b/a is shown >1, Note that rotation $\theta$, initially in the $x$-$z$
+    b/a is shown >1. Note that rotation $\theta$, initially in the $x$-$z$
     plane, is carried out first, then rotation $\phi$ about the $z$-axis,
     finally rotation $\Psi$ is around the axis of the cylinder. The neutron
-    or X-ray beam is along the $z$ axis.
+    or X-ray beam is along the $-z$ axis.
 
 .. figure::
     orient_img/elliptical_cylinder_angle_projection.png
@@ -39,58 +44,143 @@ particle.
     Some examples of the orientation angles for an elliptical cylinder,
     with $\Psi$ = 0.
 
-Having established the mean direction of the particle we can then apply
-angular orientation distributions. This is done by a numerical integration
-over a range of angles in a similar way to particle size dispersity.
-In the current version of sasview the orientational dispersity is defined
-with respect to the axes of the particle.
+Having established the mean direction of the particle (the view) we can then
+apply angular orientation distributions (jitter). This is done by a numerical
+integration over a range of angles in a similar way to particle size
+dispersity. The orientation dispersity is defined with respect to the
+$a$-$b$-$c$ axes of the particle, with roll angle $\Psi$ about the $c$-axis,
+yaw angle $\theta$ about the $b$-axis and pitch angle $\phi$ about the
+$a$-axis.
+
+More formally, starting with axes $a$-$b$-$c$ of the particle aligned
+with axes $x$-$y$-$z$ of the laboratory frame, the orientation dispersity
+is applied first, using the
+`Tait-Bryan <https://en.wikipedia.org/wiki/Euler_angles#Conventions_2>`_
+$x$-$y'$-$z''$ convention with angles $\Delta\phi$-$\Delta\theta$-$\Delta\Psi$.
+The reference orientation then follows, using the
+`Euler angles <https://en.wikipedia.org/wiki/Euler_angles#Conventions>`_
+$z$-$y'$-$z''$ with angles $\phi$-$\theta$-$\Psi$.  This is implemented
+using rotation matrices as
+
+.. math::
+
+    R = R_z(\phi)\, R_y(\theta)\, R_z(\Psi)\,
+        R_x(\Delta\phi)\, R_y(\Delta\theta)\, R_z(\Delta\Psi)
+
+To transform detector $(q_x, q_y)$ values into $(q_a, q_b, q_c)$ for the
+shape in its canonical orientation, use
+
+.. math::
+
+    [q_a, q_b, q_c]^T = R^{-1} \, [q_x, q_y, 0]^T
+
+
+The inverse rotation is easily calculated by rotating the opposite directions
+in the reverse order, so
+
+.. math::
+
+    R^{-1} = R_z(-\Delta\Psi)\, R_y(-\Delta\theta)\, R_x(-\Delta\phi)\,
+             R_z(-\Psi)\, R_y(-\theta)\, R_z(-\phi)
+
 
 The $\theta$ and $\phi$ orientation parameters for the cylinder only appear
-when fitting 2d data. On introducing "Orientational Distribution" in
-the angles, "distribution of theta" and "distribution of phi" parameters will
+when fitting 2d data. On introducing "Orientation Distribution" in the
+angles, "distribution of theta" and "distribution of phi" parameters will
 appear. These are actually rotations about the axes $\delta_1$ and $\delta_2$
-of the cylinder, the $b$ and $a$ axes of the cylinder cross section. (When
-$\theta = \phi = 0$ these are parallel to the $Y$ and $X$ axes of the
-instrument.) The third orientation distribution, in $\Psi$, is about the $c$
-axis of the particle. Some experimentation may be required to understand the
-2d patterns fully. A number of different shapes of distribution are
-available, as described for polydispersity, see :ref:`polydispersityhelp` .
+of the cylinder, which correspond to the $b$ and $a$ axes of the cylinder
+cross section. (When $\theta = \phi = 0$ these are parallel to the $Y$ and
+$X$ axes of the instrument.) The third orientation distribution, in $\Psi$,
+is about the $c$ axis of the particle. Some experimentation may be required
+to understand the 2d patterns fully. A number of different shapes of
+distribution are available, as described for size dispersity, see
+:ref:`polydispersityhelp`.
 
-Earlier versions of SasView had numerical integration issues in some
-circumstances when distributions passed through 90 degrees. The distributions
-in particle coordinates are more robust, but should still be approached with
-care for large ranges of angle.
+Given that the angular dispersion distribution is defined in cartesian space,
+over a cube defined by
+
+.. math::
+
+    [-\Delta \theta, \Delta \theta] \times
+    [-\Delta \phi, \Delta \phi] \times
+    [-\Delta \Psi, \Delta \Psi]
+
+but the orientation is defined over a sphere, we are left with a
+`map projection <https://en.wikipedia.org/wiki/List_of_map_projections>`_
+problem, with different tradeoffs depending on how values in $\Delta\theta$
+and $\Delta\phi$ are translated into latitude/longitude on the sphere.
+
+Sasmodels is using the *equirectangular* projection. In this projection,
+square patches in angular dispersity become wedge-shaped patches on the
+sphere. To correct for the changing point density, there is a scale factor of
+$\sin(\Delta\theta)$ that applies to each point in the integral. This is not
+enough, though. Consider a shape which is tumbling freely around the $b$
+axis, with $\Delta\theta$ uniform in $[-180, 180]$. At $\pm 90$, all points
+in $\Delta\phi$ map to the pole, so the jitter will have a
+distinct angular preference. If the spin axis is normal to the beam
+(which will be the case for $\theta=90$ and $\Psi=90$), the scattering
+pattern should be circularly symmetric, but it will go to zero at $\pm 90$ due
+to the $\sin(\Delta\theta)$ correction. This problem does not appear for a shape
+that is tumbling freely around the $a$ axis, with $\Delta\phi$ uniform in
+$[-180, 180]$, so swap the $a$ and $b$ axes so $\Delta\theta < \Delta\phi$
+and adjust $\Psi$ by 90. This works with the existing sasmodels shapes
+due to symmetry.
+
+There are alternative projections. The *sinusoidal* projection works by
+scaling $\Delta\phi$ as $\Delta\theta$ increases, and dropping those points
+outside $[-180, 180]$. The distortions are a little less for middle ranges of
+$\Delta\theta$, but they are still severe for large $\Delta\theta$ and the
+model is much harder to explain. The *Guyou* projection has an excellent
+balance with reasonable distortion in both $\Delta\theta$ and $\Delta\phi$,
+as well as preserving small patches. However, it is considerably more
+expensive to implement, and we have not yet computed the distortion
+correction, measuring the degree of stretch at the
+point $(\Delta\theta, \Delta\phi)$ in the correction.
 
 .. note::
-    Note that the form factors for oriented particles are also performing
-    numerical integrations over one or more variables, so care should be taken,
-    especially with very large particles or more extreme aspect ratios. In such 
-    cases results may not be accurate, particularly at very high Q, unless the model
-    has been specifically coded to use limiting forms of the scattering equations.
-    
-    For best numerical results keep the $\theta$ distribution narrower than the $\phi$ 
-    distribution. Thus for asymmetric particles, such as elliptical_cylinder, you may 
-    need to reorder the sizes of the three axes to acheive the desired result. 
-    This is due to the issues of mapping a rectangular distribution onto the 
-    surface of a sphere.
+    Note that the form factors for oriented particles are performing
+    numerical integrations over one or more variables, so care should be
+    taken, especially with very large particles or more extreme aspect
+    ratios. In such cases results may not be accurate, particularly at very
+    high Q, unless the model has been specifically coded to use limiting
+    forms of the scattering equations.
 
-Users can experiment with the values of *Npts* and *Nsigs*, the number of steps 
-used in the integration and the range spanned in number of standard deviations. 
-The standard deviation is entered in units of degrees. For a "rectangular" 
-distribution the full width should be $\pm \sqrt(3)$ ~ 1.73 standard deviations. 
-The new "uniform" distribution avoids this by letting you directly specify the 
+    For best numerical results keep the $\theta$ distribution narrower than
+    the $\phi$ distribution. Thus for asymmetric particles, such as
+    elliptical_cylinder, you may need to reorder the sizes of the three axes
+    to acheive the desired result. This is due to the issues of mapping a
+    rectanglar distribution onto the surface of a sphere.
+
+Users can experiment with the values of *Npts* and *Nsigs*, the number of steps
+used in the integration and the range spanned in number of standard deviations.
+The standard deviation is entered in units of degrees. For a "rectangular"
+distribution the full width should be $\pm \sqrt(3)$ ~ 1.73 standard deviations.
+The new "uniform" distribution avoids this by letting you directly specify the
 half width.
 
-The angular distributions will be truncated outside of the range -180 to +180 
-degrees, so beware of using saying a broad Gaussian distribution with large value
-of *Nsigs*, as the array of *Npts* may be truncated to many fewer points than would 
-give a good integration,as well as becoming rather meaningless. (At some point 
-in the future the actual polydispersity arrays may be made available to the user 
-for inspection.)
+The angular distributions may be truncated outside of the range -180 to +180
+degrees, so beware of using saying a broad Gaussian distribution with large
+value of *Nsigs*, as the array of *Npts* may be truncated to many fewer
+points than would give a good integration,as well as becoming rather
+meaningless. (At some point in the future the actual dispersion arrays may be
+made available to the user for inspection.)
 
 Some more detailed technical notes are provided in the developer section of
 this manual :ref:`orientation_developer` .
 
+This definition of orientation is new to SasView 4.2.  In earlier versions,
+the orientation distribution appeared as a distribution of view angles.
+This led to strange effects when $c$ was aligned with $z$, where changes
+to the $\phi$ angle served only to rotate the shape about $c$, rather than
+having a consistent interpretation as the pitch of the shape relative to
+the flow field defining the reference orientation.  Prior to SasView 4.1,
+the reference orientation was defined using a Tait-Bryan convention, making
+it difficult to control.  Now, rotation in $\theta$ modifies the spacings
+in the refraction pattern, and rotation in $\phi$ rotates it in the detector
+plane.
+
+
 *Document History*
 
 | 2017-11-06 Richard Heenan
+| 2017-12-20 Paul Kienzle

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -537,18 +537,13 @@ Oriented Shapes
 
 If the scattering is dependent on the orientation of the shape, then you
 will need to include *orientation* parameters *theta*, *phi* and *psi*
-at the end of the parameter table.  Shape orientation uses *a*, *b* and *c*
-axes, corresponding to the *x*, *y* and *z* axes in the laboratory coordinate
-system, with *z* along the beam and *x*-*y* in the detector plane, with *x*
-horizontal and *y* vertical.  The *psi* parameter rotates the shape
-about its *c* axis, the *theta* parameter then rotates the *c* axis toward
-the *x* axis of the detector, then *phi* rotates the shape in the detector
-plane.  (Prior to these rotations, orientation dispersity will be applied
-as roll-pitch-yaw, rotating *c*, then *b* then *a* in the shape coordinate
-system.)  A particular *qx*, *qy* point on the detector, then corresponds
-to *qa*, *qb*, *qc* with respect to the shape.
+at the end of the parameter table.  As described in the section
+:ref:`orientation`, the individual $(q_x, q_y)$ points on the detector will
+be rotated into $(q_a, q_b, q_c)$ points relative to the sample in its
+canonical orientation with $a$-$b$-$c$ aligned with $x$-$y$-$z$ in the
+laboratory frame and beam travelling along $-z$.
 
-The oriented C model is called as *Iqabc(qa, qb, qc, par1, par2, ...)* where
+The oriented C model is called using *Iqabc(qa, qb, qc, par1, par2, ...)* where
 *par1*, etc. are the parameters to the model.  If the shape is rotationally
 symmetric about *c* then *psi* is not needed, and the model is called
 as *Iqac(qab, qc, par1, par2, ...)*.  In either case, the orientation

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -639,7 +639,7 @@ Magnetism
 
 Magnetism is supported automatically for all shapes by modifying the
 effective SLD of particle according to the Halpern-Johnson vector
-describing the interation between neutron spin and magnetic field.  All
+describing the interaction between neutron spin and magnetic field.  All
 parameters marked as type *sld* in the parameter table are treated as
 possibly magnetic particles with magnitude *M0* and direction
 *mtheta* and *mphi*.  Polarization parameters are also provided

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -498,10 +498,13 @@ includes only the volume parameters.
 
 **source=['fn.c', ...]** includes the listed C source files in the
 program before *Iq* and *form_volume* are defined. This allows you to
-extend the library of C functions available to your model.  Note that
+extend the library of C functions available to your model.
+
+*c_code* includes arbitrary C code into your kernel, which can be
+handy for defining helper functions for *Iq* and *form_volume*. Note that
 you can put the full function definition for *Iq* and *form_volume*
-(include function declaration) into an external C file and add it to the list
-of sources instead of defining it within the python model file.
+(include function declaration) into *c_code* as well, or put them into an
+external C file and add that file to the list of sources.
 
 Models are defined using double precision declarations for the
 parameters and return values.  When a model is run using single
@@ -525,6 +528,9 @@ Rather than returning NAN from Iq, you must define the *INVALID(v)*.  The
 *v.par1*, *v.par2*, etc. For example::
 
     #define INVALID(v) (v.bell_radius < v.radius)
+
+The INVALID define can go into *Iq*, or *c_code*, or an external C file
+listed in *source*.
 
 Oriented Shapes
 ...............

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -291,8 +291,9 @@ defines the parameters that form the model.
 
 **Note: The order of the parameters in the definition will be the order of the
 parameters in the user interface and the order of the parameters in Iq(),
-Iqxy() and form_volume(). And** *scale* **and** *background* **parameters are
-implicit to all models, so they do not need to be included in the parameter table.**
+Iqac(), Iqabc() and form_volume(). And** *scale* **and** *background*
+**parameters are implicit to all models, so they do not need to be included
+in the parameter table.**
 
 - **"name"** is the name of the parameter shown on the FitPage.
 
@@ -361,11 +362,13 @@ implicit to all models, so they do not need to be included in the parameter tabl
     examined, the effective sld for that material will be used to compute the
     scattered intensity.
 
-  - "volume" parameters are passed to Iq(), Iqxy(), and form_volume(), and
-    have polydispersity loops generated automatically.
+  - "volume" parameters are passed to Iq(), Iqac(), Iqabc() and form_volume(),
+    and have polydispersity loops generated automatically.
 
-  - "orientation" parameters are only passed to Iqxy(), and have angular
-    dispersion.
+  - "orientation" parameters are not passed, but instead are combined with
+    orientation dispersity to translate *qx* and *qy* to *qa*, *qb* and *qc*.
+    These parameters should appear at the end of the table with the specific
+    names *theta*, *phi* and for asymmetric shapes *psi*, in that order.
 
 Some models will have integer parameters, such as number of pearls in the
 pearl necklace model, or number of shells in the multi-layer vesicle model.
@@ -418,9 +421,7 @@ computed value is
 
 That is, the individual models do not need to include polydispersity
 calculations, but instead rely on numerical integration to compute the
-appropriately smeared pattern.   Angular dispersion values over polar angle
-$\theta$ requires an additional $\cos \theta$ weighting due to decreased
-arc length for the equatorial angle $\phi$ with increasing latitude.
+appropriately smeared pattern.
 
 Python Models
 .............
@@ -468,10 +469,6 @@ Return np.NaN if the parameters are not valid (e.g., cap_radius < radius in
 barbell).  If I(q; pars) is NaN for any $q$, then those parameters will be
 ignored, and not included in the calculation of the weighted polydispersity.
 
-Similar to *Iq*, you can define *Iqxy(qx, qy, par1, par2, ...)* where the
-parameter list includes any orientation parameters.  If *Iqxy* is not defined,
-then it will default to *Iqxy = Iq(sqrt(qx**2+qy**2), par1, par2, ...)*.
-
 Models should define *form_volume(par1, par2, ...)* where the parameter
 list includes the *volume* parameters in order.  This is used for a weighted
 volume normalization so that scattering is on an absolute scale.  If
@@ -496,18 +493,15 @@ This expands into the equivalent C code::
         return I(q, par1, par2, ...);
     }
 
-*Iqxy* is similar to *Iq*, except it uses parameters *qx, qy* instead of *q*,
-and it includes orientation parameters.
-
 *form_volume* defines the volume of the shape. As in python models, it
 includes only the volume parameters.
 
-*Iqxy* will default to *Iq(sqrt(qx**2 + qy**2), par1, ...)* and
-*form_volume* will default to 1.0.
-
 **source=['fn.c', ...]** includes the listed C source files in the
-program before *Iq* and *Iqxy* are defined. This allows you to extend the
-library of C functions available to your model.
+program before *Iq* and *form_volume* are defined. This allows you to
+extend the library of C functions available to your model.  Note that
+you can put the full function definition for *Iq* and *form_volume*
+(include function declaration) into an external C file and add it to the list
+of sources instead of defining it within the python model file.
 
 Models are defined using double precision declarations for the
 parameters and return values.  When a model is run using single
@@ -531,6 +525,111 @@ Rather than returning NAN from Iq, you must define the *INVALID(v)*.  The
 *v.par1*, *v.par2*, etc. For example::
 
     #define INVALID(v) (v.bell_radius < v.radius)
+
+Oriented Shapes
+...............
+
+If the scattering is dependent on the orientation of the shape, then you
+will need to include *orientation* parameters *theta*, *phi* and *psi*
+at the end of the parameter table.  Shape orientation uses *a*, *b* and *c*
+axes, corresponding to the *x*, *y* and *z* axes in the laboratory coordinate
+system, with *z* along the beam and *x*-*y* in the detector plane, with *x*
+horizontal and *y* vertical.  The *psi* parameter rotates the shape
+about its *c* axis, the *theta* parameter then rotates the *c* axis toward
+the *x* axis of the detector, then *phi* rotates the shape in the detector
+plane.  (Prior to these rotations, orientation dispersity will be applied
+as roll-pitch-yaw, rotating *c*, then *b* then *a* in the shape coordinate
+system.)  A particular *qx*, *qy* point on the detector, then corresponds
+to *qa*, *qb*, *qc* with respect to the shape.
+
+The oriented C model is called as *Iqabc(qa, qb, qc, par1, par2, ...)* where
+*par1*, etc. are the parameters to the model.  If the shape is rotationally
+symmetric about *c* then *psi* is not needed, and the model is called
+as *Iqac(qab, qc, par1, par2, ...)*.  In either case, the orientation
+parameters are not included in the function call.
+
+For 1D oriented shapes, an integral over all angles is usually needed for
+the *Iq* function. Using symmetry and the substitution $u = \cos(\alpha)$,
+$du = -\sin(\alpha)\,d\alpha$ this becomes
+
+.. math::
+
+    I(q) &= \int_{-\pi/2}^{pi/2} \int_{-pi}^{pi}
+           F(q_a = q \sin(\alpha)\sin(\beta),
+             q_b = q \sin(\alpha)\cos(\beta),
+             q_c = q \cos(\alpha))^2 \sin(\alpha)\,d\beta\,d\alpha/(4\pi) \\
+        &= 8/(4\pi) \int_{0}^{pi/2} \int_{0}^{\pi/2} F^2 \sin(\alpha)\,d\beta\,d\alpha \\
+        &= 8/(4\pi) \int_0^1 \int_{0}^{\pi/2} F^2 \,d\beta\,du
+
+Using the $z, w$ values for Gauss-Legendre integration in "lib/gauss76.c", the
+numerical integration is then::
+
+    double outer_sum = 0.0;
+    for (int i = 0; i < GAUSS_N; i++) {
+        const double cos_alpha = 0.5*GAUSS_Z[i] + 0.5;
+        const double sin_alpha = sqrt(1.0 - cos_alpha*cos_alpha);
+        const double qc = cos_alpha * q;
+        double inner_sum = 0.0;
+        for (int j = 0; j < GAUSS_N; j++) {
+            const double beta = M_PI_4 * GAUSS_Z[j] + M_PI_4;
+            double sin_beta, cos_beta;
+            SINCOS(beta, sin_beta, cos_beta);
+            const double qb = sin_alpha * cos_beta * q;
+            const double qa = sin_alpha * sin_beta * q;
+            const double Fq = F(qa, qb, qc, ...);
+            inner_sum += GAUSS_W[j] * Fq*Fq;
+        }
+        outer_sum += GAUSS_W[i] * inner_sum;
+    }
+    outer_sum *= 0.25; // = 8/(4 pi) * outer_sum * (pi/2) / 4
+
+The *z* values for the Gauss-Legendre integration extends from -1 to 1, so
+the double sum of *w[i]w[j]* explains the factor of 4.  Correcting for the
+average *dz[i]dz[j]* gives $(1-0) \cdot (\pi/2-0) = \pi/2$.  The $8/(4 \pi)$
+factor comes from the integral over the quadrant.  With less symmetry (eg.,
+in the bcc and fcc paracrystal models), then an integral over the entire
+sphere may be necessary.
+
+For simpler models which are rotationally symmetric a single integral
+suffices:
+
+.. math::
+
+    I(q) &= \int_{-\pi/2}^{\pi/2} F(q_{ab} = q \sin(\alpha),
+            q_c = q \cos(\alpha))^2 \sin(\alpha)\,d\alpha/\pi \\
+         &= (2/\pi) \int_0^1 F^2\,du
+
+with integration loop::
+
+    double sum = 0.0;
+    for (int i = 0; i < GAUSS_N; i++) {
+        const double cos_alpha = 0.5*GAUSS_Z[i] + 0.5;
+        const double sin_alpha = sqrt(1.0 - cos_alpha*cos_alpha);
+        const double qc = cos_alpha * q;
+        const double qab = sin_alpha * q;
+        const double Fq = F(qab, qc, ...);
+        sum += GAUSS_W[j] * Fq*Fq;
+    }
+    sum *= 0.5; // = 2/pi * sum * (pi/2) / 2
+
+Magnetism
+.........
+
+Magnetism is supported automatically for all shapes by modifying the
+effective SLD of particle according to the Halpern-Johnson vector
+describing the interation between neutron spin and magnetic field.  All
+parameters marked as type *sld* in the parameter table are treated as
+possibly magnetic particles with magnitude *M0* and direction
+*mtheta* and *mphi*.  Polarization parameters are also provided
+automatically for magnetic models to set the spin state of the measurement.
+
+For more complicated systems where magnetism is not uniform throughout
+the individual particles, you will need to write your own models.
+You should not mark the nuclear sld as type *sld*, but instead leave
+them unmarked and provide your own magnetism and polarization parameters.
+For 2D measurements you will need $(q_x, q_y)$ values for the measurement
+to compute the proper magnetism and orientation, which you can implement
+using *Iqxy(qx, qy, par1, par2, ...)*.
 
 Special Functions
 .................
@@ -795,15 +894,6 @@ Although it can be difficult to get your model to work on the GPU, the reward
 can be a model that runs 1000x faster on a good card.  Even your laptop may
 show a 50x improvement or more over the equivalent pure python model.
 
-External C Models
-.................
-
-External C models are very much like embedded C models, except that
-*Iq*, *Iqxy* and *form_volume* are defined in an external source file
-loaded using the *source=[...]* statement. You need to supply the function
-declarations for each of these that you need instead of building them
-automatically from the parameter table.
-
 
 .. _Form_Factors:
 
@@ -1005,7 +1095,7 @@ We are not aiming for zero lint just yet, only keeping it to a minimum.
 For now, don't worry too much about *invalid-name*. If you really want a
 variable name *Rg* for example because $R_g$ is the right name for the model
 parameter then ignore the lint errors.  Also, ignore *missing-docstring*
-for standard model functions *Iq*, *Iqxy*, etc.
+for standard model functions *Iq*, *Iqac*, etc.
 
 We will have delinting sessions at the SasView Code Camps, where we can
 decide on standards for model files, parameter names, etc.

--- a/explore/jitter.py
+++ b/explore/jitter.py
@@ -164,6 +164,7 @@ PROJECTIONS = [
     # in order of PROJECTION number; do not change without updating the
     # constants in kernel_iq.c
     'equirectangular', 'sinusoidal', 'guyou', 'azimuthal_equidistance',
+    'azimuthal_equal_area',
 ]
 def draw_mesh(ax, view, jitter, radius=1.2, n=11, dist='gaussian',
               projection='equirectangular'):

--- a/explore/precision.py
+++ b/explore/precision.py
@@ -344,7 +344,7 @@ add_function(
     ocl_function=make_ocl("return (1-sas_sinx_x(q))/q;", "sas_1msinx_x_x"),
 )
 add_function(
-    name="(1/2+(1-cos(x))/x^2-sin(x)/x)/x",
+    name="(1/2-sin(x)/x+(1-cos(x))/x^2)/x",
     mp_function=lambda x: (0.5 - mp.sin(x)/x + (1-mp.cos(x))/(x*x))/x,
     np_function=lambda x: (0.5 - np.sin(x)/x + (1-np.cos(x))/(x*x))/x,
     ocl_function=make_ocl("return (0.5-sin(q)/q + (1-cos(q))/q/q)/q;", "sas_T2"),
@@ -608,7 +608,7 @@ ALL_FUNCTIONS.discard("2J1/x:alt")
 def usage():
     names = ", ".join(sorted(ALL_FUNCTIONS))
     print("""\
-usage: precision.py [-f/a/r] [-x<range>] name...
+usage: precision.py [-f/a/r] [-x<range>] "name" ...
 where
     -f indicates that the function value should be plotted,
     -a indicates that the absolute error should be plotted,
@@ -619,7 +619,7 @@ where
       linear indicates linear stepping in [1, 1000]
       zoom indicates linear stepping in [1000, 1010]
       neg indicates linear stepping in [-100.1, 100.1]
-and name is "all [first]" or one of:
+and name is "all" or one of:
     """+names)
     sys.exit(1)
 

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -91,6 +91,7 @@ Options (* for default):
     -magnetic/-nonmagnetic* suppress magnetism
     -accuracy=Low accuracy of the resolution calculation Low, Mid, High, Xhigh
     -neval=1 sets the number of evals for more accurate timing
+    -ngauss=0 overrides the number of points in the 1-D gaussian quadrature
 
     === precision options ===
     -engine=default uses the default calcution precision

--- a/sasmodels/details.py
+++ b/sasmodels/details.py
@@ -257,6 +257,9 @@ def correct_theta_weights(parameters, # type: ParameterTable
                          ):
     # type: (...) -> Sequence[np.ndarray]
     """
+    **Deprecated** Theta weights will be computed in the kernel wrapper if
+    they are needed.
+
     If there is a theta parameter, update the weights of that parameter so that
     the cosine weighting required for polar integration is preserved.
 
@@ -271,14 +274,12 @@ def correct_theta_weights(parameters, # type: ParameterTable
 
     Returns updated weights vectors
     """
-    # TODO: explain in a comment why scale and background are missing
     # Apparently the parameters.theta_offset similarly skips scale and
     # and background, so the indexing works out, but they are still shipped
     # to the kernel, so we need to add two there.
     if parameters.theta_offset >= 0:
         index = parameters.theta_offset
         theta = dispersity[index]
-        # TODO: modify the dispersity vector to avoid the theta=-90,90,270,...
         theta_weight = abs(cos(radians(theta)))
         weights = tuple(theta_weight*w if k == index else w
                         for k, w in enumerate(weights))

--- a/sasmodels/kernel_header.c
+++ b/sasmodels/kernel_header.c
@@ -149,3 +149,70 @@
 inline double square(double x) { return x*x; }
 inline double cube(double x) { return x*x*x; }
 inline double sas_sinx_x(double x) { return x==0 ? 1.0 : sin(x)/x; }
+
+// CRUFT: support old style models with orientation received qx, qy and angles
+
+// To rotate from the canonical position to theta, phi, psi, first rotate by
+// psi about the major axis, oriented along z, which is a rotation in the
+// detector plane xy. Next rotate by theta about the y axis, aligning the major
+// axis in the xz plane. Finally, rotate by phi in the detector plane xy.
+// To compute the scattering, undo these rotations in reverse order:
+//     rotate in xy by -phi, rotate in xz by -theta, rotate in xy by -psi
+// The returned q is the length of the q vector and (xhat, yhat, zhat) is a unit
+// vector in the q direction.
+// To change between counterclockwise and clockwise rotation, change the
+// sign of phi and psi.
+
+#if 1
+//think cos(theta) should be sin(theta) in new coords, RKH 11Jan2017
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(phi*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy); \
+    cn  = (q==0. ? 1.0 : (cn*qx + sn*qy)/q * sin(theta*M_PI_180));  \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_SYMMETRIC(qx, qy, theta, phi, q, sn, cn) do { \
+    SINCOS(theta*M_PI_180, sn, cn); \
+    q = sqrt(qx*qx + qy*qy);\
+    cn = (q==0. ? 1.0 : (cn*cos(phi*M_PI_180)*qx + sn*qy)/q); \
+    sn = sqrt(1 - cn*cn); \
+    } while (0)
+#endif
+
+#if 1
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, xhat, yhat, zhat) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    xhat = qxhat*(-sin_phi*sin_psi + cos_theta*cos_phi*cos_psi) \
+         + qyhat*( cos_phi*sin_psi + cos_theta*sin_phi*cos_psi); \
+    yhat = qxhat*(-sin_phi*cos_psi - cos_theta*cos_phi*sin_psi) \
+         + qyhat*( cos_phi*cos_psi - cos_theta*sin_phi*sin_psi); \
+    zhat = qxhat*(-sin_theta*cos_phi) \
+         + qyhat*(-sin_theta*sin_phi); \
+    } while (0)
+#else
+// SasView 3.x definition of orientation
+#define ORIENT_ASYMMETRIC(qx, qy, theta, phi, psi, q, cos_alpha, cos_mu, cos_nu) do { \
+    q = sqrt(qx*qx + qy*qy); \
+    const double qxhat = qx/q; \
+    const double qyhat = qy/q; \
+    double sin_theta, cos_theta; \
+    double sin_phi, cos_phi; \
+    double sin_psi, cos_psi; \
+    SINCOS(theta*M_PI_180, sin_theta, cos_theta); \
+    SINCOS(phi*M_PI_180, sin_phi, cos_phi); \
+    SINCOS(psi*M_PI_180, sin_psi, cos_psi); \
+    cos_alpha = cos_theta*cos_phi*qxhat + sin_theta*qyhat; \
+    cos_mu = (-sin_theta*cos_psi*cos_phi - sin_psi*sin_phi)*qxhat + cos_theta*cos_psi*qyhat; \
+    cos_nu = (-cos_phi*sin_psi*sin_theta + sin_phi*cos_psi)*qxhat + sin_psi*cos_theta*qyhat; \
+    } while (0)
+#endif

--- a/sasmodels/models/_spherepy.py
+++ b/sasmodels/models/_spherepy.py
@@ -87,10 +87,6 @@ def Iq(q, sld, sld_solvent, radius):
     return 1.0e-4 * fq ** 2
 Iq.vectorized = True  # Iq accepts an array of q values
 
-def Iqxy(qx, qy, sld, sld_solvent, radius):
-    return Iq(sqrt(qx ** 2 + qy ** 2), sld, sld_solvent, radius)
-Iqxy.vectorized = True  # Iqxy accepts arrays of qx, qy values
-
 def sesans(z, sld, sld_solvent, radius):
     """
     Calculate SESANS-correlation function for a solid sphere.

--- a/sasmodels/models/barbell.c
+++ b/sasmodels/models/barbell.c
@@ -89,7 +89,7 @@ Iq(double q, double sld, double solvent_sld,
 
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double sld, double solvent_sld,
     double radius_bell, double radius, double length)
 {

--- a/sasmodels/models/bcc_paracrystal.c
+++ b/sasmodels/models/bcc_paracrystal.c
@@ -106,7 +106,7 @@ static double Iq(double q, double dnn,
 }
 
 
-static double Iqxy(double qa, double qb, double qc,
+static double Iqabc(double qa, double qb, double qc,
     double dnn, double d_factor, double radius,
     double sld, double solvent_sld)
 {

--- a/sasmodels/models/capped_cylinder.c
+++ b/sasmodels/models/capped_cylinder.c
@@ -114,7 +114,7 @@ Iq(double q, double sld, double solvent_sld,
 
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double sld, double solvent_sld, double radius,
     double radius_cap, double length)
 {

--- a/sasmodels/models/core_shell_bicelle.c
+++ b/sasmodels/models/core_shell_bicelle.c
@@ -66,7 +66,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double radius,
     double thick_rim,
     double thick_face,

--- a/sasmodels/models/core_shell_bicelle_elliptical.c
+++ b/sasmodels/models/core_shell_bicelle_elliptical.c
@@ -70,7 +70,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
     double r_minor,
     double x_core,
     double thick_rim,

--- a/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.c
+++ b/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.c
@@ -78,7 +78,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
           double r_minor,
           double x_core,
           double thick_rim,
@@ -113,4 +113,3 @@ Iqxy(double qa, double qb, double qc,
     const double Aq = square( vol1*dr1*si1*be1 + vol2*dr2*si1*be2 +  vol3*dr3*si2*be1);
     return 1.0e-4 * Aq*exp(-0.5*(square(qa) + square(qb) + square(qc) )*square(sigma));
 }
-

--- a/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
+++ b/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
@@ -148,10 +148,10 @@ parameters = [
     ["sld_face",       "1e-6/Ang^2", 7, [-inf, inf], "sld",         "Cylinder face scattering length density"],
     ["sld_rim",        "1e-6/Ang^2", 1, [-inf, inf], "sld",         "Cylinder rim scattering length density"],
     ["sld_solvent",    "1e-6/Ang^2", 6, [-inf, inf], "sld",         "Solvent scattering length density"],
+    ["sigma",       "Ang",        0,    [0, inf],    "",            "interfacial roughness"],
     ["theta",       "degrees",    90.0, [-360, 360], "orientation", "cylinder axis to beam angle"],
     ["phi",         "degrees",    0,    [-360, 360], "orientation", "rotation about beam"],
     ["psi",         "degrees",    0,    [-360, 360], "orientation", "rotation about cylinder axis"],
-    ["sigma",       "Ang",        0,    [0, inf],    "",            "interfacial roughness"]
     ]
 
 # pylint: enable=bad-whitespace, line-too-long

--- a/sasmodels/models/core_shell_cylinder.c
+++ b/sasmodels/models/core_shell_cylinder.c
@@ -47,7 +47,7 @@ Iq(double q,
 }
 
 
-double Iqxy(double qab, double qc,
+double Iqac(double qab, double qc,
     double core_sld,
     double shell_sld,
     double solvent_sld,

--- a/sasmodels/models/core_shell_ellipsoid.c
+++ b/sasmodels/models/core_shell_ellipsoid.c
@@ -74,7 +74,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double radius_equat_core,
     double x_core,
     double thick_shell,

--- a/sasmodels/models/core_shell_parallelepiped.c
+++ b/sasmodels/models/core_shell_parallelepiped.c
@@ -42,8 +42,8 @@ Iq(double q,
 {
     // Code converted from functions CSPPKernel and CSParallelepiped in libCylinder.c
     // Did not understand the code completely, it should be rechecked (Miguel Gonzalez)
-    // Code is rewritten,the code is compliant with Diva Singhs thesis now (Dirk Honecker)
-    // Code rewritten (PAK)
+    // Code is rewritten, the code is compliant with Diva Singh's thesis now (Dirk Honecker)
+    // Code rewritten; cross checked against hollow rectangular prism and realspace (PAK)
 
     const double half_q = 0.5*q;
 
@@ -120,8 +120,6 @@ Iqabc(double qa, double qb, double qc,
     const double drB = brim_sld-solvent_sld;
     const double drC = crim_sld-solvent_sld;
 
-    // The definitions of ta, tb, tc are not the same as in the 1D case because there is no
-    // the scaling by B.
     const double tA = length_a + 2.0*thick_rim_a;
     const double tB = length_b + 2.0*thick_rim_b;
     const double tC = length_c + 2.0*thick_rim_c;

--- a/sasmodels/models/core_shell_parallelepiped.c
+++ b/sasmodels/models/core_shell_parallelepiped.c
@@ -101,7 +101,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
     double core_sld,
     double arim_sld,
     double brim_sld,

--- a/sasmodels/models/core_shell_parallelepiped.py
+++ b/sasmodels/models/core_shell_parallelepiped.py
@@ -135,8 +135,10 @@ Authorship and Verification
 
 * **Author:** NIST IGOR/DANSE **Date:** pre 2010
 * **Converted to sasmodels by:** Miguel Gonzales **Date:** February 26, 2016
-* **Last Modified by:** Wojciech Potrzebowski **Date:** January 11, 2017
-* **Currently Under review by:** Paul Butler
+* **Last Modified by:** Paul Kienzle **Date:** October 17, 2017
+* Cross-checked against hollow rectangular prism and rectangular prism for
+  equal thickness overlapping sides, and by Monte Carlo sampling of points
+  within the shape for non-uniform, non-overlapping sides.
 """
 
 import numpy as np

--- a/sasmodels/models/cylinder.c
+++ b/sasmodels/models/cylinder.c
@@ -44,7 +44,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double sld,
     double solvent_sld,
     double radius,

--- a/sasmodels/models/ellipsoid.c
+++ b/sasmodels/models/ellipsoid.c
@@ -38,7 +38,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double sld,
     double sld_solvent,
     double radius_polar,

--- a/sasmodels/models/elliptical_cylinder.c
+++ b/sasmodels/models/elliptical_cylinder.c
@@ -53,7 +53,7 @@ Iq(double q, double radius_minor, double r_ratio, double length,
 
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
      double radius_minor, double r_ratio, double length,
      double sld, double solvent_sld)
 {

--- a/sasmodels/models/fcc_paracrystal.c
+++ b/sasmodels/models/fcc_paracrystal.c
@@ -79,7 +79,7 @@ static double Iq(double q, double dnn,
 }
 
 
-static double Iqxy(double qa, double qb, double qc,
+static double Iqabc(double qa, double qb, double qc,
     double dnn, double d_factor, double radius,
     double sld, double solvent_sld)
 {

--- a/sasmodels/models/hollow_cylinder.c
+++ b/sasmodels/models/hollow_cylinder.c
@@ -51,7 +51,7 @@ Iq(double q, double radius, double thickness, double length,
 }
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double radius, double thickness, double length,
     double sld, double solvent_sld)
 {

--- a/sasmodels/models/hollow_rectangular_prism.c
+++ b/sasmodels/models/hollow_rectangular_prism.c
@@ -84,7 +84,7 @@ double Iq(double q,
     return 1.0e-4 * delrho * delrho * form;
 }
 
-double Iqxy(double qa, double qb, double qc,
+double Iqabc(double qa, double qb, double qc,
     double sld,
     double solvent_sld,
     double length_a,

--- a/sasmodels/models/line.py
+++ b/sasmodels/models/line.py
@@ -56,6 +56,7 @@ def Iq(q, intercept, slope):
 
 Iq.vectorized = True # Iq accepts an array of q values
 
+
 def Iqxy(qx, qy, *args):
     """
     :param qx:   Input q_x-value
@@ -68,6 +69,14 @@ def Iqxy(qx, qy, *args):
     return Iq(qx, *args)*Iq(qy, *args)
 
 Iqxy.vectorized = True  # Iqxy accepts an array of qx qy values
+
+# uncomment the following to test Iqxy in C models
+#del Iq, Iqxy
+#c_code = """
+#static double Iq(double q, double b, double m) { return m*q+b; }
+#static double Iqxy(double qx, double qy, double b, double m)
+#{ return (m*qx+b)*(m*qy+b); }
+#"""
 
 def random():
     scale = 10**np.random.uniform(0, 3)

--- a/sasmodels/models/parallelepiped.c
+++ b/sasmodels/models/parallelepiped.c
@@ -52,7 +52,7 @@ Iq(double q,
 
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
     double sld,
     double solvent_sld,
     double length_a,

--- a/sasmodels/models/rectangular_prism.c
+++ b/sasmodels/models/rectangular_prism.c
@@ -70,7 +70,7 @@ double Iq(double q,
 }
 
 
-double Iqxy(double qa, double qb, double qc,
+double Iqabc(double qa, double qb, double qc,
     double sld,
     double solvent_sld,
     double length_a,

--- a/sasmodels/models/sc_paracrystal.c
+++ b/sasmodels/models/sc_paracrystal.c
@@ -81,7 +81,7 @@ Iq(double q, double dnn,
 
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
     double dnn, double d_factor, double radius,
     double sld, double solvent_sld)
 {

--- a/sasmodels/models/stacked_disks.c
+++ b/sasmodels/models/stacked_disks.c
@@ -141,7 +141,7 @@ Iq(
 
 
 static double
-Iqxy(double qab, double qc,
+Iqac(double qab, double qc,
     double thick_core,
     double thick_layer,
     double radius,

--- a/sasmodels/models/triaxial_ellipsoid.c
+++ b/sasmodels/models/triaxial_ellipsoid.c
@@ -45,7 +45,7 @@ Iq(double q,
 }
 
 static double
-Iqxy(double qa, double qb, double qc,
+Iqabc(double qa, double qb, double qc,
     double sld,
     double sld_solvent,
     double radius_equat_minor,


### PR DESCRIPTION
Support old Iqxy interface as well as new Iqac/Iqabc interface.   The Iqxy interface is need for functions which operate in 2D data but do not use an orientation transform.  For example, a q-dependent background.  This may also be useful for non-uniform magnetic scattering, which needs more control over the interpretation of q than available in the Iqac/Iqabc interface.

Orientation dispersity is not supported in the Iqxy interface.