### PR TITLE
add support for pytest and use it on travis/appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 - conda update --yes conda
 - conda info -a
 # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-- conda install --yes python=$PY numpy scipy cython mako cffi "pytest<4"
+- conda install --yes python=$PY numpy scipy cython mako docutils cffi "pytest<4"
 install:
 - pip install bumps
 - pip install unittest-xml-reporting

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ before_install:
 - conda update --yes conda
 - conda info -a
 # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-- conda install --yes python=$PY numpy scipy cython mako docutils cffi setuptools "pytest<4"
+- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools "pytest<4"
 install:
 - pip install bumps
-- pip install unittest-xml-reporting
+- pip install unittest-xml-reporting tinycc
 script:
 - python --version
 #- python -m sasmodels.model_test -v dll all

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ before_install:
 - hash -r
 - conda update --yes conda
 - conda info -a
-# 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools "pytest<4"
+- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools pytest
 install:
 - pip install bumps
 - pip install unittest-xml-reporting tinycc

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 script:
 - python --version
 #- python -m sasmodels.model_test -v dll all
-- python -m pytest -v
+- python -m pytest -v --cache-clear
 before_deploy:
 - echo -e "Host danse.chem.utk.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,15 @@ before_install:
 - hash -r
 - conda update --yes conda
 - conda info -a
-- conda install --yes python=$PY numpy scipy cython mako cffi
+# 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
+- conda install --yes python=$PY numpy scipy cython mako cffi "pytest<4"
 install:
 - pip install bumps
 - pip install unittest-xml-reporting
 script:
 - python --version
-- python -m sasmodels.model_test -v dll all
+#- python -m sasmodels.model_test -v dll all
+- python -m pytest -v
 before_deploy:
 - echo -e "Host danse.chem.utk.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,15 @@ before_install:
 - conda update --yes conda
 - conda info -a
 # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-- conda install --yes python=$PY numpy scipy cython mako docutils cffi "pytest<4"
+- conda install --yes python=$PY numpy scipy cython mako docutils cffi setuptools "pytest<4"
 install:
 - pip install bumps
 - pip install unittest-xml-reporting
 script:
 - python --version
 #- python -m sasmodels.model_test -v dll all
-- python -m pytest -v --cache-clear
+#- python -m pytest -v --cache-clear
+- python setup.py test --pytest-args -v
 before_deploy:
 - echo -e "Host danse.chem.utk.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ platform:
     - x64
 
 install:
-    # Set the CONDA_NPY, although it has no impact on the actual build. 
+    # Set the CONDA_NPY, although it has no impact on the actual build.
     # We need this because of a test within conda-build.
     - cmd: set CONDA_NPY=19
 
@@ -67,7 +67,8 @@ install:
     #- cmd: conda config --set show_channel_urls true
     #- cmd: conda install --yes --quiet obvious-ci
     # 2018-01-19 PAK: skipping toolchain cython and cffi (these were for pyopencl?)
-    - cmd: conda install --yes --quiet numpy scipy
+    # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
+    - cmd: conda install --yes --quiet numpy scipy "pytest<4"
     # 2018-01-19 PAK: skipping pyopencl; this would be needed for deploy but maybe not for test
     #- cmd: conda install --yes --channel conda-forge pyopencl
     # 2018-01-19 PAK: 3rd party packages might need msvc, so %CMD_IN_ENV% may be needed for pip
@@ -85,4 +86,6 @@ test_script:
     # 2018-01-19 PAK: maybe need one of this if using msvc?
     #- "%CMD_IN_ENV% python -m sasmodels.model_test dll all"
     #- cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd python -m sasmoels.model_test dll all
-    - python -m sasmodels.model_test dll all
+    #- python -m sasmodels.model_test dll all
+    #- nosetests -v sasmodels/*.py
+    - python -m pytest -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
     #- cmd: conda install --yes --quiet obvious-ci
     # 2018-01-19 PAK: skipping toolchain cython and cffi (these were for pyopencl?)
     # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-    - cmd: conda install --yes --quiet numpy scipy docutils "pytest<4"
+    - cmd: conda install --yes --quiet numpy scipy docutils setuptools "pytest<4"
     # 2018-01-19 PAK: skipping pyopencl; this would be needed for deploy but maybe not for test
     #- cmd: conda install --yes --channel conda-forge pyopencl
     # 2018-01-19 PAK: 3rd party packages might need msvc, so %CMD_IN_ENV% may be needed for pip
@@ -88,4 +88,5 @@ test_script:
     #- cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd python -m sasmoels.model_test dll all
     #- python -m sasmodels.model_test dll all
     #- nosetests -v sasmodels/*.py
-    - python -m pytest -v --cache-clear
+    #- python -m pytest -v --cache-clear
+    - python setup.py test --pytest-args -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
     #- cmd: conda install --yes --quiet obvious-ci
     # 2018-01-19 PAK: skipping toolchain cython and cffi (these were for pyopencl?)
     # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-    - cmd: conda install --yes --quiet numpy scipy docutils setuptools "pytest<4"
+    - cmd: conda install --yes --quiet numpy scipy matplotlib docutils setuptools "pytest<4"
     # 2018-01-19 PAK: skipping pyopencl; this would be needed for deploy but maybe not for test
     #- cmd: conda install --yes --channel conda-forge pyopencl
     # 2018-01-19 PAK: 3rd party packages might need msvc, so %CMD_IN_ENV% may be needed for pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
     #- cmd: conda install --yes --quiet obvious-ci
     # 2018-01-19 PAK: skipping toolchain cython and cffi (these were for pyopencl?)
     # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-    - cmd: conda install --yes --quiet numpy scipy "pytest<4"
+    - cmd: conda install --yes --quiet numpy scipy docutils "pytest<4"
     # 2018-01-19 PAK: skipping pyopencl; this would be needed for deploy but maybe not for test
     #- cmd: conda install --yes --channel conda-forge pyopencl
     # 2018-01-19 PAK: 3rd party packages might need msvc, so %CMD_IN_ENV% may be needed for pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,4 +88,4 @@ test_script:
     #- cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd python -m sasmoels.model_test dll all
     #- python -m sasmodels.model_test dll all
     #- nosetests -v sasmodels/*.py
-    - python -m pytest -v
+    - python -m pytest -v --cache-clear

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,8 +67,7 @@ install:
     #- cmd: conda config --set show_channel_urls true
     #- cmd: conda install --yes --quiet obvious-ci
     # 2018-01-19 PAK: skipping toolchain cython and cffi (these were for pyopencl?)
-    # 2018-01-26 PAK: sasmodels uses yield generator for tests, which isn't supported in pytest 4+
-    - cmd: conda install --yes --quiet numpy scipy matplotlib docutils setuptools "pytest<4"
+    - cmd: conda install --yes --quiet numpy scipy matplotlib docutils setuptools pytest
     # 2018-01-19 PAK: skipping pyopencl; this would be needed for deploy but maybe not for test
     #- cmd: conda install --yes --channel conda-forge pyopencl
     # 2018-01-19 PAK: 3rd party packages might need msvc, so %CMD_IN_ENV% may be needed for pip

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,65 @@
+"""
+py.test hooks for sasmodels
+
+Hooks for running sasmodels tests via py.test.
+
+*pytest_collection_modifyitems* adds the test description to the end of
+the test name.  This is needed for the generated list of tests is sasmodels,
+where each test has a description giving the name of the model.  For example
+"model_tests::[3]" becomes "model_tests::[3]::bcc_paracrystal-dll".  Need to
+leave the "::[3]" in the name since that is the way you can indicate this
+test specifically from the py.test command line. [This is perhaps because
+the modifyitems hook is only called after test selection.]
+"""
+from __future__ import print_function
+
+import pytest
+from _pytest.unittest import TestCaseFunction
+
+USE_DOCSTRING_AS_DESCRIPTION = True
+def pytest_collection_modifyitems(session, config, items):
+    """
+    Add description to the test node id if item is a function and function
+    has a description attribute or __doc__ attribute.
+    """
+    for item in items:
+        #print(item.nodeid, type(item))
+        #for attr in dir(item): not attr.startswith('__') and print(attr, getattr(item, attr))
+        if isinstance(item, pytest.Function):
+            if isinstance(item, TestCaseFunction):
+                # TestCase uses item.name to find the method so skip
+                continue
+            function = item.obj
+
+            # If the test case provides a "description" attribute then use it
+            # as an extended description.  If there is no description attribute,
+            # then perhaps use the test docstring.
+            if USE_DOCSTRING_AS_DESCRIPTION:
+                description = getattr(function, 'description', function.__doc__)
+            else:
+                description = getattr(function, 'description', "")
+
+            # If description is not supplied but yield args are, then use the
+            # yield args for the description
+            if not description and getattr(item, '_args', ()):
+                description = str(item._args) if len(item._args) > 1 else str(item._args[0])
+            #print(item.nodeid, description, item._args)
+
+            if description:
+                # Strip spaces from start and end and strip dots from end
+                # pytest converts '.' to '::' on output for some reason.
+                description = description.strip().rstrip('.')
+                # Join multi-line descriptions into a single line
+                if '\n' in description:
+                    description = " ".join(line.strip() for line in description.split('\n'))
+
+            # Set the description as part of the node identifier.
+            if description:
+                #print(type(item), dir(item))
+                #print(item.nodeid, description)
+                #print(item.location, item.name, item.nodeid, item.originalname)
+                # Note: leave the current name mostly as-is since the prefix
+                # is needed to specify the nth test from a list of tests.
+                #print("updating with", description)
+                item.name += "::" + description
+            #print("=>", item.nodeid)

--- a/conftest.py
+++ b/conftest.py
@@ -16,10 +16,10 @@ the modifyitems hook is only called after test selection.]
 from __future__ import print_function
 
 import os.path
+import inspect
 
 import pytest
 from _pytest.unittest import TestCaseFunction
-from _pytest.compat import is_generator
 
 def pytest_pycollect_makeitem(collector, name, obj):
     """
@@ -54,6 +54,17 @@ def pytest_pycollect_makeitem(collector, name, obj):
             test = pytest.Function(name+index, collector, args=args, callobj=call)
             tests.append(test)
         return tests
+
+def is_generator(func):
+    """
+    Returns True if function has yield.
+    """
+    # Cribbed from _pytest.compat is_generator and iscoroutinefunction; these
+    # may not be available as part of pytest 4.
+    coroutine = (getattr(func, '_is_coroutine', False) or
+                 getattr(inspect, 'iscoroutinefunction', lambda f: False)(func))
+    generator = inspect.isgeneratorfunction(func)
+    return generator and not coroutine
 
 def split_yielded_test(obj, number):
     if not isinstance(obj, (tuple, list)):

--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,9 @@ import pytest
 from _pytest.unittest import TestCaseFunction
 
 try:
-    import pyopencl
+    # Ask OpenCL for the default context so that we know that one exists
+    import pyopencl as cl
+    cl.create_some_context(interactive=False)
     TEST_PYOPENCL = True
 except ImportError:
     TEST_PYOPENCL = False

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,14 @@
 """
-py.test hooks for sasmodels
+pytest hooks for sasmodels
 
-Hooks for running sasmodels tests via py.test.
+Hooks for running sasmodels tests via pytest.
 
 *pytest_collection_modifyitems* adds the test description to the end of
 the test name.  This is needed for the generated list of tests is sasmodels,
 where each test has a description giving the name of the model.  For example
 "model_tests::[3]" becomes "model_tests::[3]::bcc_paracrystal-dll".  Need to
 leave the "::[3]" in the name since that is the way you can indicate this
-test specifically from the py.test command line. [This is perhaps because
+test specifically from the pytest command line. [This is perhaps because
 the modifyitems hook is only called after test selection.]
 
 *pytest_ignore_collect* skips kernelcl.py if pyopencl cannot be imported.
@@ -73,8 +73,6 @@ def pytest_collection_modifyitems(session, config, items):
     has a description attribute or __doc__ attribute.
     """
     for item in items:
-        #print(item.nodeid, type(item))
-        #for attr in dir(item): not attr.startswith('__') and print(attr, getattr(item, attr))
         if isinstance(item, pytest.Function):
             if isinstance(item, TestCaseFunction):
                 # TestCase uses item.name to find the method so skip
@@ -92,24 +90,19 @@ def pytest_collection_modifyitems(session, config, items):
             # If description is not supplied but yield args are, then use the
             # yield args for the description
             if not description and getattr(item, '_args', ()):
-                description = str(item._args) if len(item._args) > 1 else str(item._args[0])
-            #print(item.nodeid, description, item._args)
+                description = (str(item._args) if len(item._args) > 1
+                               else str(item._args[0]))
 
+            # Set the description as part of the node identifier.
             if description:
                 # Strip spaces from start and end and strip dots from end
                 # pytest converts '.' to '::' on output for some reason.
                 description = description.strip().rstrip('.')
                 # Join multi-line descriptions into a single line
                 if '\n' in description:
-                    description = " ".join(line.strip() for line in description.split('\n'))
+                    description = " ".join(line.strip()
+                                           for line in description.split('\n'))
 
-            # Set the description as part of the node identifier.
-            if description:
-                #print(type(item), dir(item))
-                #print(item.nodeid, description)
-                #print(item.location, item.name, item.nodeid, item.originalname)
                 # Note: leave the current name mostly as-is since the prefix
                 # is needed to specify the nth test from a list of tests.
-                #print("updating with", description)
                 item.name += "::" + description
-            #print("=>", item.nodeid)

--- a/conftest.py
+++ b/conftest.py
@@ -20,18 +20,6 @@ import os.path
 import pytest
 from _pytest.unittest import TestCaseFunction
 
-try:
-    # Ask OpenCL for the default context so that we know that one exists
-    import pyopencl as cl
-    cl.create_some_context(interactive=False)
-    TEST_PYOPENCL = True
-except ImportError:
-    TEST_PYOPENCL = False
-
-def pytest_ignore_collect(path, config):
-    ignore = TEST_PYOPENCL and path.basename == "kernelcl.py"
-    return ignore
-
 USE_DOCSTRING_AS_DESCRIPTION = True
 def pytest_collection_modifyitems(session, config, items):
     """

--- a/conftest.py
+++ b/conftest.py
@@ -10,11 +10,25 @@ where each test has a description giving the name of the model.  For example
 leave the "::[3]" in the name since that is the way you can indicate this
 test specifically from the py.test command line. [This is perhaps because
 the modifyitems hook is only called after test selection.]
+
+*pytest_ignore_collect* skips kernelcl.py if pyopencl cannot be imported.
 """
 from __future__ import print_function
 
+import os.path
+
 import pytest
 from _pytest.unittest import TestCaseFunction
+
+try:
+    import pyopencl
+    TEST_PYOPENCL = True
+except ImportError:
+    TEST_PYOPENCL = False
+
+def pytest_ignore_collect(path, config):
+    ignore = TEST_PYOPENCL and path.basename == "kernelcl.py"
+    return ignore
 
 USE_DOCSTRING_AS_DESCRIPTION = True
 def pytest_collection_modifyitems(session, config, items):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = --doctest-modules
+doctest_optionflags = ELLIPSIS
+testpaths = sasmodels
+python_files = *.py
+python_classes = NoClassTestsWillMatch
+python_functions = *_test test_* model_tests

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -39,6 +39,7 @@ import numpy as np  # type: ignore
 
 from . import core
 from . import kerneldll
+from . import kernelcl
 from .data import plot_theory, empty_data1D, empty_data2D, load_data
 from .direct_model import DirectModel, get_mesh
 from .generate import FLOAT_RE, set_integration_size
@@ -622,43 +623,6 @@ def suppress_magnetism(pars, suppress=True):
     return pars
 
 
-DTYPE_MAP = {
-    'half': '16',
-    'fast': 'fast',
-    'single': '32',
-    'double': '64',
-    'quad': '128',
-    'f16': '16',
-    'f32': '32',
-    'f64': '64',
-    'float16': '16',
-    'float32': '32',
-    'float64': '64',
-    'float128': '128',
-    'longdouble': '128',
-}
-def eval_opencl(model_info, data, dtype='single', cutoff=0.):
-    # type: (ModelInfo, Data, str, float) -> Calculator
-    """
-    Return a model calculator using the OpenCL calculation engine.
-    """
-    if not core.HAVE_OPENCL:
-        raise RuntimeError("OpenCL not available")
-    model = core.build_model(model_info, dtype=dtype, platform="ocl")
-    calculator = DirectModel(data, model, cutoff=cutoff)
-    calculator.engine = "OCL%s"%DTYPE_MAP[str(model.dtype)]
-    return calculator
-
-def eval_ctypes(model_info, data, dtype='double', cutoff=0.):
-    # type: (ModelInfo, Data, str, float) -> Calculator
-    """
-    Return a model calculator using the DLL calculation engine.
-    """
-    model = core.build_model(model_info, dtype=dtype, platform="dll")
-    calculator = DirectModel(data, model, cutoff=cutoff)
-    calculator.engine = "OMP%s"%DTYPE_MAP[str(model.dtype)]
-    return calculator
-
 def time_calculation(calculator, pars, evals=1):
     # type: (Calculator, ParameterSet, int) -> Tuple[np.ndarray, float]
     """
@@ -706,6 +670,37 @@ def make_data(opts):
         index = slice(None, None)
     return data, index
 
+DTYPE_MAP = {
+    'half': '16',
+    'fast': 'fast',
+    'single': '32',
+    'double': '64',
+    'quad': '128',
+    'f16': '16',
+    'f32': '32',
+    'f64': '64',
+    'float16': '16',
+    'float32': '32',
+    'float64': '64',
+    'float128': '128',
+    'longdouble': '128',
+}
+def eval_opencl(model_info, data, dtype='single', cutoff=0.):
+    # type: (ModelInfo, Data, str, float) -> Calculator
+    """
+    Return a model calculator using the OpenCL calculation engine.
+    """
+
+def eval_ctypes(model_info, data, dtype='double', cutoff=0.):
+    # type: (ModelInfo, Data, str, float) -> Calculator
+    """
+    Return a model calculator using the DLL calculation engine.
+    """
+    model = core.build_model(model_info, dtype=dtype, platform="dll")
+    calculator = DirectModel(data, model, cutoff=cutoff)
+    calculator.engine = "OMP%s"%DTYPE_MAP[str(model.dtype)]
+    return calculator
+
 def make_engine(model_info, data, dtype, cutoff, ngauss=0):
     # type: (ModelInfo, Data, str, float) -> Calculator
     """
@@ -717,10 +712,16 @@ def make_engine(model_info, data, dtype, cutoff, ngauss=0):
     if ngauss:
         set_integration_size(model_info, ngauss)
 
-    if dtype is None or not dtype.endswith('!'):
-        return eval_opencl(model_info, data, dtype=dtype, cutoff=cutoff)
-    else:
-        return eval_ctypes(model_info, data, dtype=dtype[:-1], cutoff=cutoff)
+    if dtype != "default" and not dtype.endswith('!') and not kernelcl.use_opencl():
+        raise RuntimeError("OpenCL not available " + kernelcl.OPENCL_ERROR)
+
+    model = core.build_model(model_info, dtype=dtype, platform="ocl")
+    calculator = DirectModel(data, model, cutoff=cutoff)
+    engine_type = calculator._model.__class__.__name__.replace('Model','').upper()
+    bits = calculator._model.dtype.itemsize*8
+    precision = "fast" if getattr(calculator._model, 'fast', False) else str(bits)
+    calculator.engine = "%s[%s]" % (engine_type, precision)
+    return calculator
 
 def _show_invalid(data, theory):
     # type: (Data, np.ma.ndarray) -> None

--- a/sasmodels/convert.py
+++ b/sasmodels/convert.py
@@ -632,7 +632,6 @@ def _check_one(name, seed=None):
 
 def test_backward_forward():
     from .core import list_models
+    L = lambda name: _check_one(name, seed=1)
     for name in list_models('all'):
-        L = lambda: _check_one(name, seed=1)
-        L.description = name
-        yield L
+        yield L, name

--- a/sasmodels/core.py
+++ b/sasmodels/core.py
@@ -20,17 +20,12 @@ from . import modelinfo
 from . import product
 from . import mixture
 from . import kernelpy
+from . import kernelcl
 from . import kerneldll
 from . import custom
 
-if os.environ.get("SAS_OPENCL", "").lower() == "none":
-    HAVE_OPENCL = False
-else:
-    try:
-        from . import kernelcl
-        HAVE_OPENCL = True
-    except Exception:
-        HAVE_OPENCL = False
+# Other modules look for HAVE_OPENCL in core, not in kernelcl.
+HAVE_OPENCL = kernelcl.HAVE_OPENCL
 
 CUSTOM_MODEL_PATH = os.environ.get('SAS_MODELPATH', "")
 if CUSTOM_MODEL_PATH == "":

--- a/sasmodels/core.py
+++ b/sasmodels/core.py
@@ -24,15 +24,6 @@ from . import kernelcl
 from . import kerneldll
 from . import custom
 
-# Other modules look for HAVE_OPENCL in core, not in kernelcl.
-HAVE_OPENCL = kernelcl.HAVE_OPENCL
-
-CUSTOM_MODEL_PATH = os.environ.get('SAS_MODELPATH', "")
-if CUSTOM_MODEL_PATH == "":
-    CUSTOM_MODEL_PATH = joinpath(os.path.expanduser("~"), ".sasmodels", "custom_models")
-    if not os.path.isdir(CUSTOM_MODEL_PATH):
-        os.makedirs(CUSTOM_MODEL_PATH)
-
 # pylint: disable=unused-import
 try:
     from typing import List, Union, Optional, Any
@@ -41,6 +32,12 @@ try:
 except ImportError:
     pass
 # pylint: enable=unused-import
+
+CUSTOM_MODEL_PATH = os.environ.get('SAS_MODELPATH', "")
+if CUSTOM_MODEL_PATH == "":
+    CUSTOM_MODEL_PATH = joinpath(os.path.expanduser("~"), ".sasmodels", "custom_models")
+    if not os.path.isdir(CUSTOM_MODEL_PATH):
+        os.makedirs(CUSTOM_MODEL_PATH)
 
 # TODO: refactor composite model support
 # The current load_model_info/build_model does not reuse existing model
@@ -270,7 +267,7 @@ def parse_dtype(model_info, dtype=None, platform=None):
 
     if platform is None:
         platform = "ocl"
-    if platform == "ocl" and not HAVE_OPENCL or not model_info.opencl:
+    if not kernelcl.use_opencl() or not model_info.opencl:
         platform = "dll"
 
     # Check if type indicates dll regardless of which platform is given

--- a/sasmodels/core.py
+++ b/sasmodels/core.py
@@ -319,49 +319,56 @@ def list_models_main():
     kind = sys.argv[1] if len(sys.argv) > 1 else "all"
     print("\n".join(list_models(kind)))
 
-def test_load():
-    # type: () -> None
-    """Check that model load works"""
+def test_composite_order():
     def test_models(fst, snd):
         """Confirm that two models produce the same parameters"""
         fst = load_model(fst)
         snd = load_model(snd)
-        # Remove the upper case characters frin the parameters, since
-        # they lasndel the order of events and we specfically are
-        # changin that aspect
+        # Un-disambiguate parameter names so that we can check if the same
+        # parameters are in a pair of composite models. Since each parameter in
+        # the mixture model is tagged as e.g., A_sld, we ought to use a
+        # regex subsitution s/^[A-Z]+_/_/, but removing all uppercase letters
+        # is good enough.
         fst = [[x for x in p.name if x == x.lower()] for p in fst.info.parameters.kernel_parameters]
         snd = [[x for x in p.name if x == x.lower()] for p in snd.info.parameters.kernel_parameters]
         assert sorted(fst) == sorted(snd), "{} != {}".format(fst, snd)
 
+    def build_test(first, second):
+        test = lambda description: test_models(first, second)
+        description = first + " vs. " + second
+        return test, description
 
-    test_models(
+    yield build_test(
         "cylinder+sphere",
         "sphere+cylinder")
-    test_models(
+    yield build_test(
         "cylinder*sphere",
         "sphere*cylinder")
-    test_models(
+    yield build_test(
         "cylinder@hardsphere*sphere",
         "sphere*cylinder@hardsphere")
-    test_models(
+    yield build_test(
         "barbell+sphere*cylinder@hardsphere",
         "sphere*cylinder@hardsphere+barbell")
-    test_models(
+    yield build_test(
         "barbell+cylinder@hardsphere*sphere",
         "cylinder@hardsphere*sphere+barbell")
-    test_models(
+    yield build_test(
         "barbell+sphere*cylinder@hardsphere",
         "barbell+cylinder@hardsphere*sphere")
-    test_models(
+    yield build_test(
         "sphere*cylinder@hardsphere+barbell",
         "cylinder@hardsphere*sphere+barbell")
-    test_models(
+    yield build_test(
         "barbell+sphere*cylinder@hardsphere",
         "cylinder@hardsphere*sphere+barbell")
-    test_models(
+    yield build_test(
         "barbell+cylinder@hardsphere*sphere",
         "sphere*cylinder@hardsphere+barbell")
 
+def test_composite():
+    # type: () -> None
+    """Check that model load works"""
     #Test the the model produces the parameters that we would expect
     model = load_model("cylinder@hardsphere*sphere")
     actual = [p.name for p in model.info.parameters.kernel_parameters]

--- a/sasmodels/jitter.py
+++ b/sasmodels/jitter.py
@@ -12,7 +12,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 import argparse
 
-import mpl_toolkits.mplot3d   # Adds projection='3d' option to subplot
+try: # CRUFT: travis-ci does not support mpl_toolkits.mplot3d
+    import mpl_toolkits.mplot3d  # Adds projection='3d' option to subplot
+except ImportError:
+    pass
+
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, CheckButtons
 from matplotlib import cm

--- a/sasmodels/kernelcl.py
+++ b/sasmodels/kernelcl.py
@@ -147,11 +147,13 @@ def environment():
 
     This provides an OpenCL context and one queue per device.
     """
-    if not HAVE_OPENCL:
-        warnings.warn("OpenCL startup failed with ***"
-                      + OPENCL_ERROR + "***; using C compiler instead")
-    elif ENV is None:
+    if ENV is None:
+        if not HAVE_OPENCL:
+            raise RuntimeError("OpenCL startup failed with ***"
+                            + OPENCL_ERROR + "***; using C compiler instead")
         reset_environment()
+        if ENV is None:
+            raise RuntimeError("SAS_OPENCL=None in environment")
     return ENV
 
 def has_type(device, dtype):

--- a/sasmodels/kernelcl.py
+++ b/sasmodels/kernelcl.py
@@ -57,14 +57,13 @@ import time
 
 import numpy as np  # type: ignore
 
-import pyopencl as cl  # type: ignore
-from pyopencl import mem_flags as mf
-from pyopencl.characterize import get_fast_inaccurate_build_options
-
 try:
     if os.environ.get("SAS_OPENCL", "").lower() == "none":
         HAVE_OPENCL = False
     else:
+        import pyopencl as cl  # type: ignore
+        from pyopencl import mem_flags as mf
+        from pyopencl.characterize import get_fast_inaccurate_build_options
         # Ask OpenCL for the default context so that we know that one exists
         cl.create_some_context(interactive=False)
         HAVE_OPENCL = True

--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -160,7 +160,6 @@ def make_suite(loaders, models):
 
     return suite
 
-
 def _hide_model_case_from_nose():
     # type: () -> type
     class ModelTestCase(unittest.TestCase):
@@ -468,11 +467,17 @@ def model_tests():
     """
     loaders = ['opencl', 'dll'] if core.HAVE_OPENCL else ['dll']
     tests = make_suite(loaders, ['all'])
-    for test in tests:
+    def build_test(test):
         # In order for nosetest to show the test name, wrap the test.run_all
         # instance in function that takes the test name as a parameter which
-        # will be displayed when the test is run.
-        yield lambda name: test.run_all(), test.test_name
+        # will be displayed when the test is run.  Do this as a function so
+        # that it properly captures the context for tests that captured and
+        # run later.  If done directly in the for loop, then the looping
+        # variable test will be shared amongst all the tests, and we will be
+        # repeatedly testing vesicle.
+        return lambda name: test.run_all(), test.test_name
+    for test in tests:
+        yield build_test(test)
 
 
 if __name__ == "__main__":

--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -122,7 +122,7 @@ def make_suite(loaders, models):
         stash = []
 
         if is_py:  # kernel implemented in python
-            test_name = "Model: %s, Kernel: python"%model_name
+            test_name = "%s-python"%model_name
             test_method_name = "test_%s_python" % model_info.id
             test = ModelTestCase(test_name, model_info,
                                  test_method_name,
@@ -134,7 +134,7 @@ def make_suite(loaders, models):
 
             # test using dll if desired
             if 'dll' in loaders or not core.HAVE_OPENCL:
-                test_name = "Model: %s, Kernel: dll"%model_name
+                test_name = "%s-dll"%model_name
                 test_method_name = "test_%s_dll" % model_info.id
                 test = ModelTestCase(test_name, model_info,
                                      test_method_name,
@@ -145,7 +145,7 @@ def make_suite(loaders, models):
 
             # test using opencl if desired and available
             if 'opencl' in loaders and core.HAVE_OPENCL:
-                test_name = "Model: %s, Kernel: OpenCL"%model_name
+                test_name = "%s-opencl"%model_name
                 test_method_name = "test_%s_opencl" % model_info.id
                 # Using dtype=None so that the models that are only
                 # correct for double precision are not tested using
@@ -468,15 +468,11 @@ def model_tests():
     """
     loaders = ['opencl', 'dll'] if core.HAVE_OPENCL else ['dll']
     tests = make_suite(loaders, ['all'])
-    for test_i in tests:
-        # In order for nosetest to see the correct test name, need to set
-        # the description attribute of the returned function.  Since we
-        # can't do this for the returned instance, wrap it in a lambda and
-        # set the description on the lambda.  Otherwise we could just do:
-        #    yield test_i.run_all
-        L = lambda: test_i.run_all()
-        L.description = test_i.test_name
-        yield L
+    for test in tests:
+        # In order for nosetest to show the test name, wrap the test.run_all
+        # instance in function that takes the test name as a parameter which
+        # will be displayed when the test is run.
+        yield lambda name: test.run_all(), test.test_name
 
 
 if __name__ == "__main__":

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -664,7 +664,6 @@ class SasviewModel(object):
             return self._calculate_Iq(qx, qy)
 
     def _calculate_Iq(self, qx, qy=None):
-        #core.HAVE_OPENCL = False
         if self._model is None:
             self._model = core.build_model(self._model_info)
         if qy is not None:

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -858,7 +858,7 @@ def test_model_list():
 def test_old_name():
     # type: () -> None
     """
-    Load and run cylinder model from sas.models.CylinderModel
+    Load and run cylinder model as sas-models-CylinderModel
     """
     if not SUPPORT_OLD_STYLE_PLUGINS:
         return

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,20 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+import sys
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ''
+
+    def run_tests(self):
+        import shlex
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
 
 def find_version(package):
     """Read package version string from __init__.py"""
@@ -47,11 +60,14 @@ setup(
         'sasmodels.models': ['*.c', 'lib/*.c'],
         'sasmodels': ['*.c', '*.cl'],
     },
-    install_requires = [
+    install_requires=[
     ],
-    extras_require = {
+    extras_require={
         'OpenCL': ["pyopencl"],
         'Bumps': ["bumps"],
         'TinyCC': ["tinycc"],
     },
+    build_requires=['setuptools'],
+    test_requires=['pytest'],
+    cmdclass = {'test': PyTest},
 )


### PR DESCRIPTION
The existing repo only checks the models, and doesn't run the rest of the tests in the repo.

This patch adds support for pytest (since nose is no longer being developed, and nose2 didn't work) to the travis-ci and appveyor builds.  

Now tests such as the mixture model tests added to the core by @rprospero in #61 will be run during the build, and commits such as 8698a0ddea5 by @pkienzle (which broke mixtures of oriented shapes) won't go undetected so long.