### PR TITLE
Ticket 1052: Allow custom models to be used in sum|multi models

### DIFF
--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -168,7 +168,8 @@ from __future__ import print_function
 #__all__ = ["model_info", "make_doc", "make_source", "convert_type"]
 
 import sys
-from os.path import abspath, dirname, join as joinpath, exists, getmtime
+from os import environ
+from os.path import abspath, dirname, join as joinpath, exists, getmtime, sep
 import re
 import string
 from zlib import crc32
@@ -896,12 +897,20 @@ def load_kernel_module(model_name):
     :func:`sasmodels.custom.load_custom_kernel_module`, otherwise
     load it from :mod:`sasmodels.models`.
     """
+    # TODO: Keep current scheme (.py looks in custom folders)
+    plugin_path = environ.get('PLUGIN_MODEL_DIR', None)
     if model_name.endswith('.py'):
         kernel_module = load_custom_kernel_module(model_name)
     else:
-        from sasmodels import models
-        __import__('sasmodels.models.'+model_name)
-        kernel_module = getattr(models, model_name, None)
+        try:
+            from sasmodels import models
+            __import__('sasmodels.models.'+model_name)
+            kernel_module = getattr(models, model_name, None)
+        except Exception:
+            if plugin_path is not None:
+                file_name = model_name.split(sep)[-1]
+                model_name = plugin_path + sep + file_name + ".py"
+            kernel_module = load_custom_kernel_module(model_name)
     return kernel_module
 
 

--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -906,7 +906,7 @@ def load_kernel_module(model_name):
             kernel_module = getattr(models, model_name, None)
         except ImportError:
             # If the model isn't a built in model, try the plugin directory
-            plugin_path = environ.get('PLUGIN_MODEL_DIR', None)
+            plugin_path = environ.get('SAS_MODELPATH', None)
             if plugin_path is not None:
                 file_name = model_name.split(sep)[-1]
                 model_name = plugin_path + sep + file_name + ".py"

--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -897,8 +897,6 @@ def load_kernel_module(model_name):
     :func:`sasmodels.custom.load_custom_kernel_module`, otherwise
     load it from :mod:`sasmodels.models`.
     """
-    # TODO: Keep current scheme (.py looks in custom folders)
-    plugin_path = environ.get('PLUGIN_MODEL_DIR', None)
     if model_name.endswith('.py'):
         kernel_module = load_custom_kernel_module(model_name)
     else:
@@ -906,11 +904,15 @@ def load_kernel_module(model_name):
             from sasmodels import models
             __import__('sasmodels.models.'+model_name)
             kernel_module = getattr(models, model_name, None)
-        except Exception:
+        except ImportError:
+            # If the model isn't a built in model, try the plugin directory
+            plugin_path = environ.get('PLUGIN_MODEL_DIR', None)
             if plugin_path is not None:
                 file_name = model_name.split(sep)[-1]
                 model_name = plugin_path + sep + file_name + ".py"
-            kernel_module = load_custom_kernel_module(model_name)
+                kernel_module = load_custom_kernel_module(model_name)
+            else:
+                raise
     return kernel_module
 
 


### PR DESCRIPTION
I defined an environment variable PLUGIN_MODEL_DIR that is defined within sasview and only used in sasmodels. When load_kernel_module in generate.py cannot find a model by name and an ImportError is thrown, sasmodels looks for the model in the directory set in PLUGIN_MODEL_DIR, if if the variable has been defined. If that search fails, the error propagates up.

This PR depends on [sasview PR 146](https://github.com/SasView/sasview/pull/146).