### PR TITLE
limit pinhole resolution integral to +/- 2.5 dq

### DIFF
--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -666,7 +666,10 @@ def make_data(opts):
             q = np.linspace(qmin, qmax, nq)
         if opts['zero']:
             q = np.hstack((0, q))
-        data = empty_data1D(q, resolution=res)
+        # TODO: provide command line control of lambda and Delta lambda/lambda
+        #L, dLoL = 5, 0.14/np.sqrt(6)  # wavelength and 14% triangular FWHM
+        L, dLoL = 0, 0
+        data = empty_data1D(q, resolution=res, L=L, dL=L*dLoL)
         index = slice(None, None)
     return data, index
 
@@ -870,6 +873,7 @@ def plot_models(opts, result, limits=None, setnum=0):
 
     # Plot if requested
     view = opts['view']
+    #view = 'log'
     if limits is None:
         vmin, vmax = np.inf, -np.inf
         if have_base:

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -644,7 +644,7 @@ def time_calculation(calculator, pars, evals=1):
     return value, average_time
 
 def make_data(opts):
-    # type: (Dict[str, Any]) -> Tuple[Data, np.ndarray]
+    # type: (Dict[str, Any], float) -> Tuple[Data, np.ndarray]
     """
     Generate an empty dataset, used with the model to set Q points
     and resolution.
@@ -785,7 +785,7 @@ def run_models(opts, verbose=False):
     base, comp = opts['engines']
     base_n, comp_n = opts['count']
     base_pars, comp_pars = opts['pars']
-    data = opts['data']
+    base_data, comp_data = opts['data']
 
     comparison = comp is not None
 
@@ -799,7 +799,7 @@ def run_models(opts, verbose=False):
         if verbose:
             print("%s t=%.2f ms, intensity=%.0f"
                   % (base.engine, base_time, base_value.sum()))
-        _show_invalid(data, base_value)
+        _show_invalid(base_data, base_value)
     except ImportError:
         traceback.print_exc()
 
@@ -811,7 +811,7 @@ def run_models(opts, verbose=False):
             if verbose:
                 print("%s t=%.2f ms, intensity=%.0f"
                       % (comp.engine, comp_time, comp_value.sum()))
-            _show_invalid(data, comp_value)
+            _show_invalid(base_data, comp_value)
         except ImportError:
             traceback.print_exc()
 
@@ -865,7 +865,7 @@ def plot_models(opts, result, limits=None, setnum=0):
 
     have_base, have_comp = (base_value is not None), (comp_value is not None)
     base, comp = opts['engines']
-    data = opts['data']
+    base_data, comp_data = opts['data']
     use_data = (opts['datafile'] is not None) and (have_base ^ have_comp)
 
     # Plot if requested
@@ -883,15 +883,15 @@ def plot_models(opts, result, limits=None, setnum=0):
     if have_base:
         if have_comp:
             plt.subplot(131)
-        plot_theory(data, base_value, view=view, use_data=use_data, limits=limits)
+        plot_theory(base_data, base_value, view=view, use_data=use_data, limits=limits)
         plt.title("%s t=%.2f ms"%(base.engine, base_time))
         #cbar_title = "log I"
     if have_comp:
         if have_base:
             plt.subplot(132)
         if not opts['is2d'] and have_base:
-            plot_theory(data, base_value, view=view, use_data=use_data, limits=limits)
-        plot_theory(data, comp_value, view=view, use_data=use_data, limits=limits)
+            plot_theory(comp_data, base_value, view=view, use_data=use_data, limits=limits)
+        plot_theory(comp_data, comp_value, view=view, use_data=use_data, limits=limits)
         plt.title("%s t=%.2f ms"%(comp.engine, comp_time))
         #cbar_title = "log I"
     if have_base and have_comp:
@@ -907,7 +907,10 @@ def plot_models(opts, result, limits=None, setnum=0):
             cutoff = sorted_err[int(sorted_err.size*0.95)]
             err[err > cutoff] = cutoff
         #err,errstr = base/comp,"ratio"
-        plot_theory(data, None, resid=err, view=errview, use_data=use_data)
+        # Note: base_data only since base and comp have same q values (though
+        # perhaps different resolution), and we are plotting the difference
+        # at each q
+        plot_theory(base_data, None, resid=err, view=errview, use_data=use_data)
         plt.xscale('log' if view == 'log' and not opts['is2d'] else 'linear')
         plt.legend(['P%d'%(k+1) for k in range(setnum+1)], loc='best')
         plt.title("max %s = %.3g"%(errstr, abs(err).max()))
@@ -1074,7 +1077,7 @@ def parse_opts(argv):
         'qmin'      : None,
         'qmax'      : 0.05,
         'nq'        : 128,
-        'res'       : 0.0,
+        'res'       : '0.0',
         'noise'     : 0.0,
         'accuracy'  : 'Low',
         'cutoff'    : '0.0',
@@ -1114,7 +1117,7 @@ def parse_opts(argv):
         elif arg.startswith('-nq='):       opts['nq'] = int(arg[4:])
         elif arg.startswith('-q='):
             opts['qmin'], opts['qmax'] = [float(v) for v in arg[3:].split(':')]
-        elif arg.startswith('-res='):      opts['res'] = float(arg[5:])
+        elif arg.startswith('-res='):      opts['res'] = arg[5:]
         elif arg.startswith('-noise='):    opts['noise'] = float(arg[7:])
         elif arg.startswith('-sets='):     opts['sets'] = int(arg[6:])
         elif arg.startswith('-accuracy='): opts['accuracy'] = arg[10:]
@@ -1172,10 +1175,6 @@ def parse_opts(argv):
     # Create the computational engines
     if opts['qmin'] is None:
         opts['qmin'] = 0.001*opts['qmax']
-    if opts['datafile'] is not None:
-        data = load_data(os.path.expanduser(opts['datafile']))
-    else:
-        data, _ = make_data(opts)
 
     comparison = any(PAR_SPLIT in v for v in values)
 
@@ -1215,10 +1214,31 @@ def parse_opts(argv):
     else:
         opts['cutoff'] = [float(opts['cutoff'])]*2
 
-    base = make_engine(model_info[0], data, opts['engine'][0],
+    if PAR_SPLIT in opts['res']:
+        opts['res'] = [float(k) for k in opts['res'].split(PAR_SPLIT, 2)]
+        comparison = True
+    else:
+        opts['res'] = [float(opts['res'])]*2
+
+    if opts['datafile'] is not None:
+        data = load_data(os.path.expanduser(opts['datafile']))
+    else:
+        # Hack around the fact that make_data doesn't take a pair of resolutions
+        res = opts['res']
+        opts['res'] = res[0]
+        data0, _ = make_data(opts)
+        if res[0] != res[1]:
+            opts['res'] = res[1]
+            data1, _ = make_data(opts)
+        else:
+            data1 = data0
+        opts['res'] = res
+        data = data0, data1
+
+    base = make_engine(model_info[0], data[0], opts['engine'][0],
                        opts['cutoff'][0], opts['ngauss'][0])
     if comparison:
-        comp = make_engine(model_info[1], data, opts['engine'][1],
+        comp = make_engine(model_info[1], data[1], opts['engine'][1],
                            opts['cutoff'][1], opts['ngauss'][1])
     else:
         comp = None

--- a/sasmodels/jitter.py
+++ b/sasmodels/jitter.py
@@ -773,7 +773,7 @@ def run(model_name='parallelepiped', size=(10, 40, 100),
         jitter = sdtheta.val, sdphi.val, sdpsi.val
         # set small jitter as 0 if multiple pd dims
         dims = sum(v > 0 for v in jitter)
-        limit = [0, 0, 0.5, 5][dims]
+        limit = [0, 0.5, 5][dims]
         jitter = [0 if v < limit else v for v in jitter]
         axes.cla()
         draw_beam(axes, (0, 0))

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -188,8 +188,11 @@ def pinhole_resolution(q_calc, q, q_width, nsigma=PINHOLE_N_SIGMA):
     cdf = erf((edges[:, None] - q[None, :]) / (sqrt(2.0)*q_width)[None, :])
     weights = cdf[1:] - cdf[:-1]
     # Limit q range to +/- 2.5 sigma
-    weights[q_calc[:, None] < (q - nsigma*q_width)[None, :]] = 0.
-    weights[q_calc[:, None] > (q + nsigma*q_width)[None, :]] = 0.
+    qhigh = q + nsigma*q_width
+    #qlow = q - nsigma*q_width  # linear limits
+    qlow = q*q/qhigh  # log limits
+    weights[q_calc[:, None] < qlow[None, :]] = 0.
+    weights[q_calc[:, None] > qhigh[None, :]] = 0.
     weights /= np.sum(weights, axis=0)[None, :]
     return weights
 

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -85,15 +85,17 @@ class Pinhole1D(Resolution):
                        if q_calc is None else np.sort(q_calc))
 
         # Protect against models which are not defined for very low q.  Limit
-        # the smallest q value evaluated (in absolute) to 0.02*min
+        # the smallest q value evaluated to 0.02*min.  Note that negative q
+        # values are trimmed even for broad resolution.  Although not possible
+        # from the geometry, they may appear since we are using a truncated
+        # gaussian to represent resolution rather than a skew distribution.
         cutoff = MINIMUM_ABSOLUTE_Q*np.min(self.q)
-        self.q_calc = self.q_calc[abs(self.q_calc) >= cutoff]
+        self.q_calc = self.q_calc[self.q_calc >= cutoff]
 
         # Build weight matrix from calculated q values
         self.weight_matrix = pinhole_resolution(
             self.q_calc, self.q, np.maximum(q_width, MINIMUM_RESOLUTION),
             nsigma=nsigma)
-        self.q_calc = abs(self.q_calc)
 
     def apply(self, theory):
         return apply_resolution_matrix(self.weight_matrix, theory)

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -576,7 +576,7 @@ def romberg_slit_1d(q, width, height, form, pars):
     return result
 
 
-def romberg_pinhole_1d(q, q_width, form, pars, nsigma=5):
+def romberg_pinhole_1d(q, q_width, form, pars, nsigma=2.5):
     """
     Romberg integration for pinhole resolution.
 
@@ -704,10 +704,13 @@ class ResolutionTest(unittest.TestCase):
                                q_calc=self.x)
         theory = 12.0-1000.0*resolution.q_calc
         output = resolution.apply(theory)
+        # Note: answer came from output of previous run.  Non-integer
+        # values at ends come from the fact that q_calc does not
+        # extend beyond q, and so the weights don't balance.
         answer = [
-            10.44785079, 9.84991299, 8.98101708,
-            7.99906585, 6.99998311, 6.00001689,
-            5.00093415, 4.01898292, 3.15008701, 2.55214921,
+            10.47037734, 9.86925860,
+            9., 8., 7., 6., 5., 4.,
+            3.13074140, 2.52962266,
             ]
         np.testing.assert_allclose(output, answer, atol=1e-8)
 
@@ -750,6 +753,7 @@ class IgorComparisonTest(unittest.TestCase):
         output = self._eval_sphere(pars, resolution)
         self._compare(q, output, answer, 1e-6)
 
+    @unittest.skip("suppress comparison with old version; pinhole calc changed")
     def test_pinhole(self):
         """
         Compare pinhole resolution smearing with NIST Igor SANS
@@ -764,6 +768,7 @@ class IgorComparisonTest(unittest.TestCase):
         # TODO: relative error should be lower
         self._compare(q, output, answer, 3e-4)
 
+    @unittest.skip("suppress comparison with old version; pinhole calc changed")
     def test_pinhole_romberg(self):
         """
         Compare pinhole resolution smearing with romberg integration result.
@@ -779,7 +784,7 @@ class IgorComparisonTest(unittest.TestCase):
         #q_calc = interpolate(pinhole_extend_q(q, q_width, nsigma=5),
         #                     2*np.pi/pars['radius']/200)
         #tol = 0.001
-        ## The default 3 sigma and no extra points gets 1%
+        ## The default 2.5 sigma and no extra points gets 1%
         q_calc = None  # type: np.ndarray
         tol = 0.01
         resolution = Pinhole1D(q, q_width, q_calc=q_calc)


### PR DESCRIPTION
See sasview ticket http://trac.sasview.org/ticket/1102

This changes the computed pinhole resolution values, so they are now different from older versions of sasview and Igor.  The tests against the old values have been suppressed.  Instead, the code was verified by comparing the Pinhole1D calculation against the direct integral using Romberg integration.  The demo could be turned into a new test case.
