### PR TITLE
refactor tests so that gui doesn't reload module each time

### DIFF
--- a/sasmodels/kernelpy.py
+++ b/sasmodels/kernelpy.py
@@ -36,7 +36,7 @@ class PyModel(KernelModel):
         _create_default_functions(model_info)
         self.info = model_info
         self.dtype = np.dtype('d')
-        logger.info("load python model " + self.info.name)
+        logger.info("make python model " + self.info.name)
 
     def make_kernel(self, q_vectors):
         q_input = PyInput(q_vectors, dtype=F64)

--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -46,6 +46,7 @@ from __future__ import print_function
 
 import sys
 import unittest
+import traceback
 
 try:
     from StringIO import StringIO
@@ -73,7 +74,6 @@ else:
     from .kernel import KernelModel
 # pylint: enable=unused-import
 
-
 def make_suite(loaders, models):
     # type: (List[str], List[str]) -> unittest.TestSuite
     """
@@ -85,7 +85,6 @@ def make_suite(loaders, models):
 
     *models* is the list of models to test, or *["all"]* to test all models.
     """
-    ModelTestCase = _hide_model_case_from_nose()
     suite = unittest.TestSuite()
 
     if models[0] in core.KINDS:
@@ -94,72 +93,76 @@ def make_suite(loaders, models):
     else:
         skip = []
     for model_name in models:
-        if model_name in skip:
-            continue
-        model_info = load_model_info(model_name)
-
-        #print('------')
-        #print('found tests in', model_name)
-        #print('------')
-
-        # if ispy then use the dll loader to call pykernel
-        # don't try to call cl kernel since it will not be
-        # available in some environmentes.
-        is_py = callable(model_info.Iq)
-
-        # Some OpenCL drivers seem to be flaky, and are not producing the
-        # expected result.  Since we don't have known test values yet for
-        # all of our models, we are instead going to compare the results
-        # for the 'smoke test' (that is, evaluation at q=0.1 for the default
-        # parameters just to see that the model runs to completion) between
-        # the OpenCL and the DLL.  To do this, we define a 'stash' which is
-        # shared between OpenCL and DLL tests.  This is just a list.  If the
-        # list is empty (which it will be when DLL runs, if the DLL runs
-        # first), then the results are appended to the list.  If the list
-        # is not empty (which it will be when OpenCL runs second), the results
-        # are compared to the results stored in the first element of the list.
-        # This is a horrible stateful hack which only makes sense because the
-        # test suite is thrown away after being run once.
-        stash = []
-
-        if is_py:  # kernel implemented in python
-            test_name = "%s-python"%model_name
-            test_method_name = "test_%s_python" % model_info.id
-            test = ModelTestCase(test_name, model_info,
-                                 test_method_name,
-                                 platform="dll",  # so that
-                                 dtype="double",
-                                 stash=stash)
-            suite.addTest(test)
-        else:   # kernel implemented in C
-
-            # test using dll if desired
-            if 'dll' in loaders or not use_opencl():
-                test_name = "%s-dll"%model_name
-                test_method_name = "test_%s_dll" % model_info.id
-                test = ModelTestCase(test_name, model_info,
-                                     test_method_name,
-                                     platform="dll",
-                                     dtype="double",
-                                     stash=stash)
-                suite.addTest(test)
-
-            # test using opencl if desired and available
-            if 'opencl' in loaders and use_opencl():
-                test_name = "%s-opencl"%model_name
-                test_method_name = "test_%s_opencl" % model_info.id
-                # Using dtype=None so that the models that are only
-                # correct for double precision are not tested using
-                # single precision.  The choice is determined by the
-                # presence of *single=False* in the model file.
-                test = ModelTestCase(test_name, model_info,
-                                     test_method_name,
-                                     platform="ocl", dtype=None,
-                                     stash=stash)
-                #print("defining", test_name)
-                suite.addTest(test)
+        if model_name not in skip:
+            model_info = load_model_info(model_name)
+            _add_model_to_suite(loaders, suite, model_info)
 
     return suite
+
+def _add_model_to_suite(loaders, suite, model_info):
+    ModelTestCase = _hide_model_case_from_nose()
+
+    #print('------')
+    #print('found tests in', model_name)
+    #print('------')
+
+    # if ispy then use the dll loader to call pykernel
+    # don't try to call cl kernel since it will not be
+    # available in some environmentes.
+    is_py = callable(model_info.Iq)
+
+    # Some OpenCL drivers seem to be flaky, and are not producing the
+    # expected result.  Since we don't have known test values yet for
+    # all of our models, we are instead going to compare the results
+    # for the 'smoke test' (that is, evaluation at q=0.1 for the default
+    # parameters just to see that the model runs to completion) between
+    # the OpenCL and the DLL.  To do this, we define a 'stash' which is
+    # shared between OpenCL and DLL tests.  This is just a list.  If the
+    # list is empty (which it will be when DLL runs, if the DLL runs
+    # first), then the results are appended to the list.  If the list
+    # is not empty (which it will be when OpenCL runs second), the results
+    # are compared to the results stored in the first element of the list.
+    # This is a horrible stateful hack which only makes sense because the
+    # test suite is thrown away after being run once.
+    stash = []
+
+    if is_py:  # kernel implemented in python
+        test_name = "%s-python"%model_info.name
+        test_method_name = "test_%s_python" % model_info.id
+        test = ModelTestCase(test_name, model_info,
+                                test_method_name,
+                                platform="dll",  # so that
+                                dtype="double",
+                                stash=stash)
+        suite.addTest(test)
+    else:   # kernel implemented in C
+
+        # test using dll if desired
+        if 'dll' in loaders or not use_opencl():
+            test_name = "%s-dll"%model_info.name
+            test_method_name = "test_%s_dll" % model_info.id
+            test = ModelTestCase(test_name, model_info,
+                                    test_method_name,
+                                    platform="dll",
+                                    dtype="double",
+                                    stash=stash)
+            suite.addTest(test)
+
+        # test using opencl if desired and available
+        if 'opencl' in loaders and use_opencl():
+            test_name = "%s-opencl"%model_info.name
+            test_method_name = "test_%s_opencl" % model_info.id
+            # Using dtype=None so that the models that are only
+            # correct for double precision are not tested using
+            # single precision.  The choice is determined by the
+            # presence of *single=False* in the model file.
+            test = ModelTestCase(test_name, model_info,
+                                    test_method_name,
+                                    platform="ocl", dtype=None,
+                                    stash=stash)
+            #print("defining", test_name)
+            suite.addTest(test)
+
 
 def _hide_model_case_from_nose():
     # type: () -> type
@@ -347,13 +350,25 @@ def is_near(target, actual, digits=5):
     shift = 10**math.ceil(math.log10(abs(target)))
     return abs(target-actual)/shift < 1.5*10**-digits
 
-def run_one(model):
-    # type: (str) -> str
-    """
-    Run the tests for a single model, printing the results to stdout.
+# CRUFT: old interface; should be deprecated and removed
+def run_one(model_name):
+    # msg = "use check_model(model_info) rather than run_one(model_name)"
+    # warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+    try:
+        model_info = load_model_info(model_name)
+    except Exception:
+        output = traceback.format_exc()
+        return output
 
-    *model* can by a python file, which is handy for checking user defined
-    plugin models.
+    success, output = check_model(model_info)
+    return output
+
+def check_model(model_info):
+    # type: (ModelInfo) -> str
+    """
+    Run the tests for a single model, capturing the output.
+
+    Returns success status and the output string.
     """
     # Note that running main() directly did not work from within the
     # wxPython pycrust console.  Instead of the results appearing in the
@@ -368,13 +383,8 @@ def run_one(model):
 
     # Build a test suite containing just the model
     loaders = ['opencl'] if use_opencl() else ['dll']
-    models = [model]
-    try:
-        suite = make_suite(loaders, models)
-    except Exception:
-        import traceback
-        stream.writeln(traceback.format_exc())
-        return
+    suite = unittest.TestSuite()
+    _add_model_to_suite(loaders, suite, model_info)
 
     # Warn if there are no user defined tests.
     # Note: the test suite constructed above only has one test in it, which
@@ -389,7 +399,7 @@ def run_one(model):
     # for user tests before running the suite.
     for test in suite:
         if not test.info.tests:
-            stream.writeln("Note: %s has no user defined tests."%model)
+            stream.writeln("Note: %s has no user defined tests."%model_info.name)
         break
     else:
         stream.writeln("Note: no test suite created --- this should never happen")
@@ -405,7 +415,7 @@ def run_one(model):
 
     output = stream.getvalue()
     stream.close()
-    return output
+    return result.wasSuccessful(), output
 
 
 def main(*models):

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -785,6 +785,16 @@ class SasviewModel(object):
             value = self.params[par.name]
             return value, [value], [1.0]
 
+    @classmethod
+    def runTests(cls):
+        """
+        Run any tests built into the model and captures the test output.
+
+        Returns success flag and output
+        """
+        from .model_test import check_model
+        return check_model(cls._model_info)
+
 def test_cylinder():
     # type: () -> float
     """


### PR DESCRIPTION
Improve support for individual model tests in GUI by adding a runTests class method to SasviewModel.

The existing interface to the run_one() test function is preserved, so this patch could be used with the current version of Sasview.  Probably should wait until the 4.2 release is complete before applying it though.

To use the new behaviour in Sasview, the following patch should be applied:
```
diff --git a/src/sas/sasgui/perspectives/calculator/model_editor.py b/src/sas/sasgui/perspectives/calculator/model_editor.py
index 16680bdc9..58c7ea8a5 100644
--- a/src/sas/sasgui/perspectives/calculator/model_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/model_editor.py
@@ -868,7 +868,7 @@ class EditorPanel(wx.ScrolledWindow):
         name = self.name_tcl.GetValue().lstrip().rstrip()
         info = 'Info'
         msg = ''
-        result, check_err = '', ''
+        result = ''
         # Sort out the errors if occur
         # First check for valid python name then if the name already exists
         if not name or not bool(re.match('^[A-Za-z0-9_]*$', name)):
@@ -881,21 +881,19 @@ class EditorPanel(wx.ScrolledWindow):
             param_str = self.param_tcl.GetText()
             func_str = self.function_tcl.GetText()
             # No input for the model function
-            if func_str.lstrip().rstrip():
-                if func_str.count('return') > 0:
-                    self.write_file(self.fname, name, description, param_str,
-                                    func_str)
-                    try:
-                        result, msg = check_model(self.fname), None
-                    except Exception:
-                        import traceback
-                        result, msg = None, "error building model"
-                        check_err = "\n"+traceback.format_exc(limit=2)
-                else:
-                    msg = "Error: The func(x) must 'return' a value at least.\n"
-                    msg += "For example: \n\nreturn 2*x"
-            else:
+            if not func_str.lstrip().rstrip():
                 msg = 'Error: Function is not defined.'
+            elif func_str.count('return') == 0:
+                msg = "Error: The func(x) must 'return' a value at least.\n"
+                msg += "For example: \n\nreturn 2*x"
+            else:
+                self.write_file(self.fname, name, description, param_str,
+                                func_str)
+                success, output = check_model(self.fname)
+                if success:
+                    result = output
+                else:
+                    msg = output
         else:
             msg = "Name exists already."
 
@@ -921,7 +919,7 @@ class EditorPanel(wx.ScrolledWindow):
         if self.base is not None:
             from sas.sasgui.guiframe.events import StatusEvent
             wx.PostEvent(self.base.parent,
-                         StatusEvent(status=msg+check_err, info=info))
+                         StatusEvent(status=msg, info=info))
         self.warning = msg
 
     def write_file(self, fname, name, desc_str, param_str, func_str):
diff --git a/src/sas/sasgui/perspectives/calculator/pyconsole.py b/src/sas/sasgui/perspectives/calculator/pyconsole.py
index 133206a15..580126496 100644
--- a/src/sas/sasgui/perspectives/calculator/pyconsole.py
+++ b/src/sas/sasgui/perspectives/calculator/pyconsole.py
@@ -27,45 +27,10 @@ def check_model(path):
     """
     Check that the model on the path can run.
     """
-    # TODO: fix model caching
-    # model_test.run_one() is directly forcing a reload of the module, but
-    # sasview_model is caching models that have already been loaded.
-    # If the sasview load happens before the test, then the module is
-    # reloaded out from under it, which causes the global variables in
-    # the model function definitions to be cleared (at least in python 2.7).
-    # To fix the proximal problem of models failing on test, perform the
-    # run_one() tests first.  To fix the deeper problem we should either
-    # remove caching from sasmodels.sasview_model.load_custom_model() or
-    # add caching to sasmodels.custom.load_custom_kernel_module().  Another
-    # option is to add a runTests method to SasviewModel which runs the
-    # test suite directly from the model info structure.  Probably some
-    # combination of options:
-    #    (1) have this function (check_model) operate on a loaded model
-    #    so that caching isn't needed in sasview_models.load_custom_model
-    #    (2) add the runTests method to SasviewModel so that tests can
-    #    be run on a loaded module.
-    #
-    # Also, note that the model test suite runs the equivalent of the
-    # "try running the model" block below, and doesn't need to be run
-    # twice.  The reason for duplicating the block here is to generate
-    # an exception that show_model_output can catch.  Need to write the
-    # runTests method so that it returns success flag as well as output
-    # string so that the extra test is not necessary.
-
-    # check the model's unit tests run
-    from sasmodels.model_test import run_one
-    result = run_one(path)
-
     # try running the model
     from sasmodels.sasview_model import load_custom_model
     Model = load_custom_model(path)
-    model = Model()
-    q =  np.array([0.01, 0.1])
-    Iq = model.evalDistribution(q)
-    qx, qy =  np.array([0.01, 0.01]), np.array([0.1, 0.1])
-    Iqxy = model.evalDistribution([qx, qy])
-
-    return result
+    return Model.runTests()
 
 def show_model_output(parent, fname):
     # Make sure we have a python file; not sure why we care though...
@@ -74,19 +39,15 @@ def show_model_output(parent, fname):
         wx.MessageBox(str(mssg), 'Error', style=wx.ICON_ERROR)
         return False
 
-    try:
-        result, errmsg = check_model(fname), None
-    except Exception:
-        import traceback
-        result, errmsg = None, traceback.format_exc()
+    success, output = check_model(fname)
 
     parts = ["Running model '%s'..." % os.path.basename(fname)]
-    if errmsg is not None:
-        parts.extend(["", "Error occurred:", errmsg, ""])
-        title, icon = "Error", wx.ICON_ERROR
-    else:
-        parts.extend(["", "Success:", result, ""])
+    if success:
+        parts.extend(["", "Success:", output, ""])
         title, icon = "Info", wx.ICON_INFORMATION
+    else:
+        parts.extend(["", "Error occurred:", output, ""])
+        title, icon = "Error", wx.ICON_ERROR
     text = "\n".join(parts)
     dlg = ResizableScrolledMessageDialog(parent, text, title, size=((550, 250)))
     fnt = wx.Font(10, wx.TELETYPE, wx.NORMAL, wx.NORMAL)
```