### PR TITLE
avoid cancellation error causing NaN values to appear in 2D patterns

### DIFF
--- a/sasmodels/kernel_iq.c
+++ b/sasmodels/kernel_iq.c
@@ -83,7 +83,7 @@ static void set_spin_weights(double in_spin, double out_spin, double weight[6])
   in_spin = clip(in_spin, 0.0, 1.0);
   out_spin = clip(out_spin, 0.0, 1.0);
   // Previous version of this function took the square root of the weights,
-  // under the assumption that 
+  // under the assumption that
   //
   //     w*I(q, rho1, rho2, ...) = I(q, sqrt(w)*rho1, sqrt(w)*rho2, ...)
   //
@@ -187,13 +187,13 @@ static void
 qac_apply(
     QACRotation *rotation,
     double qx, double qy,
-    double *qa_out, double *qc_out)
+    double *qab_out, double *qc_out)
 {
-    const double dqc = rotation->R31*qx + rotation->R32*qy;
     // Indirect calculation of qab, from qab^2 = |q|^2 - qc^2
-    const double dqa = sqrt(-dqc*dqc + qx*qx + qy*qy);
-
-    *qa_out = dqa;
+    const double dqc = rotation->R31*qx + rotation->R32*qy;
+    const double dqab_sq = -dqc*dqc + qx*qx + qy*qy;
+    //*qab_out = sqrt(fabs(dqab_sq));
+    *qab_out = dqab_sq > 0.0 ? sqrt(dqab_sq) : 0.0;
     *qc_out = dqc;
 }
 #endif // _QAC_SECTION


### PR DESCRIPTION
On some cards some 2d patterns were occasionally showing speckles at a few points, usually with some symmetry.  This was probably due to the q rotation calculation, which computed qab from the expression: q^2 = qab^2 + qc^2.  For qab=0, tiny errors in q^2 or qc^2 could lead to negative values in the sqrt.

Try core_shell_cylinder for theta=90 with and without the fix.  Without the fix the console should report an error from the plotter about bad values encountered in comparison.

There is no ticket for this error.
