### PR TITLE
Ticket 1142, 1183: improved caching of sasmodels

### DIFF
--- a/sasmodels/custom/__init__.py
+++ b/sasmodels/custom/__init__.py
@@ -11,12 +11,13 @@ from __future__ import division, print_function
 
 import sys
 import os
-from os.path import basename, splitext
+from os.path import basename, splitext, join as joinpath, exists, dirname
 
 try:
     # Python 3.5 and up
     from importlib.util import spec_from_file_location, module_from_spec  # type: ignore
     def load_module_from_path(fullname, path):
+        # type: (str, str) -> "module"
         """load module from *path* as *fullname*"""
         spec = spec_from_file_location(fullname, os.path.expanduser(path))
         module = module_from_spec(spec)
@@ -26,6 +27,7 @@ except ImportError:
     # CRUFT: python 2
     import imp
     def load_module_from_path(fullname, path):
+        # type: (str, str) -> "module"
         """load module from *path* as *fullname*"""
         # Clear out old definitions, if any
         if fullname in sys.modules:
@@ -36,50 +38,59 @@ except ImportError:
         module = imp.load_source(fullname, os.path.expanduser(path))
         return module
 
-_MODULE_CACHE = {}
-_MODULE_DEPENDS = {}
-_MODULE_DEPENDS_STACK = []
+_MODULE_CACHE = {} # type: Dict[str, Tuple("module", int)]
+_MODULE_DEPENDS = {} # type: Dict[str, List[str]]
+_MODULE_DEPENDS_STACK = [] # type: List[str]
 def load_custom_kernel_module(path):
+    # type: str -> "module"
     """load SAS kernel from *path* as *sasmodels.custom.modelname*"""
     # Pull off the last .ext if it exists; there may be others
     name = basename(splitext(path)[0])
     path = os.path.expanduser(path)
 
-    # reload module if necessary
+    # Reload module if necessary.
     if need_reload(path):
-        # Push to the next dependency level
-        _MODULE_DEPENDS_STACK.append(path)
+        # Assume the module file is the only dependency
         _MODULE_DEPENDS[path] = set([path])
 
-        # Load module into the 'sasmodels.custom' name space.
-        # If this triggers any submodule loads then they will be added
-        # as dependencies below when _MODULE_DEPENDS_STACK is not empty.
+        # Load the module while pushing it onto the dependency stack.  If
+        # this triggers any submodules, then they will add their dependencies
+        # to this module as the "working_on" parent.  Pop the stack when the
+        # module is loaded.
+        _MODULE_DEPENDS_STACK.append(path)
         module = load_module_from_path('sasmodels.custom.'+name, path)
-
-        # Pop the dependency level
         _MODULE_DEPENDS_STACK.pop()
 
-        # TODO: include external C code in the dependencies
-        # If we had the model info structure we could do the following:
-        #    _MODEL_DEPENDS[path].extend(generate.model_sources(info))
-        # but at this point all we have is the module.  Don't want to
-        # repeat the logic in modelinfo.make_model_info.
+        # Include external C code in the dependencies.  We are looking
+        # for module.source and assuming that it is a list of C source files
+        # relative to the module itself.  Any files that do not exist,
+        # such as those in the standard libraries, will be ignored.
+        # TODO: look in builtin module path for standard c sources
+        # TODO: share code with generate.model_sources
+        c_sources = getattr(module, 'source', None)
+        if isinstance(c_sources, (list, tuple)):
+            _MODULE_DEPENDS[path].update(_find_sources(path, c_sources))
 
-        # Cache the module with the newest timestamp
+        # Cache the module, and tag it with the newest timestamp
         timestamp = max(os.path.getmtime(f) for f in _MODULE_DEPENDS[path])
         _MODULE_CACHE[path] = module, timestamp
 
         #print("loading", os.path.basename(path), _MODULE_CACHE[path][1],
         #    [os.path.basename(p) for p in _MODULE_DEPENDS[path]])
 
+    # Add path and all its dependence to the parent module, if there is one.
     if _MODULE_DEPENDS_STACK:
-        # Add child and all its dependence to the parent module
         working_on = _MODULE_DEPENDS_STACK[-1]
         _MODULE_DEPENDS[working_on].update(_MODULE_DEPENDS[path])
 
     return _MODULE_CACHE[path][0]
 
 def need_reload(path):
+    # type: str -> bool
+    """
+    Return True if any path dependencies have a timestamp newer than the time
+    when the path was most recently loaded.
+    """
     # TODO: fails if a dependency has a modification time in the future
     # If the newest dependency has a time stamp in the future, then this
     # will be recorded as the cached time.  When a second dependency
@@ -91,4 +102,20 @@ def need_reload(path):
     # correctly.  Probably not worth the extra code...
     _, cache_time = _MODULE_CACHE.get(path, (None, -1))
     depends = _MODULE_DEPENDS.get(path, [path])
+    #print("reload", any(cache_time < os.path.getmtime(p) for p in depends))
+    #for f in depends: print(">>>  ", f, os.path.getmtime(f))
     return any(cache_time < os.path.getmtime(p) for p in depends)
+
+def _find_sources(path, source_list):
+    # type: (str, List[str]) -> List[str]
+    """
+    Return a list of the sources relative to base file; ignore any that
+    are not found.
+    """
+    root = dirname(path)
+    found = []
+    for source_name in source_list:
+        source_path = joinpath(root, source_name)
+        if exists(source_path):
+            found.append(source_path)
+    return found

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -792,6 +792,8 @@ def make_model_info(kernel_module):
     info.category = getattr(kernel_module, 'category', None)
     info.structure_factor = getattr(kernel_module, 'structure_factor', False)
     info.profile_axes = getattr(kernel_module, 'profile_axes', ['x', 'y'])
+    # Note: custom.load_custom_kernel_module assumes the C sources are defined
+    # by this attribute.
     info.source = getattr(kernel_module, 'source', [])
     info.c_code = getattr(kernel_module, 'c_code', None)
     # TODO: check the structure of the tests


### PR DESCRIPTION
Sasmodels now scans c file dependencies when checking timestamps on module load.

The sasview wrapper was returning a new model each time module reload was called, even if the module itself did not change.  It now keeps its own module cache so that it only triggers a change in the model if the module has changed since the model was last loaded.  This means the plugin reload code no longer redraws each page which contains a plugin model.  This shouldn't affect the look, but it might be a little faster to reload models after a plugin change.