### PR TITLE
Ticket 1188: rename magnetic parameters to not contain colon

### DIFF
--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -367,7 +367,7 @@ def _randomize_one(model_info, name, value):
         return np.random.uniform(-0.5, 12)
 
     # Limit magnetic SLDs to a smaller range, from zero to iron=5/A^2
-    if par.name.startswith('M0:'):
+    if par.name.endswith('_M0'):
         return np.random.uniform(0, 5)
 
     # Guess at the random length/radius/thickness.  In practice, all models
@@ -537,7 +537,7 @@ def parlist(model_info, pars, is2d):
     magnetic = False
     magnetic_pars = []
     for p in parameters.user_parameters(pars, is2d):
-        if any(p.id.startswith(x) for x in ('M0:', 'mtheta:', 'mphi:')):
+        if any(p.id.endswith(x) for x in ('_M0', '_mtheta', '_mphi')):
             continue
         if p.id.startswith('up:'):
             magnetic_pars.append("%s=%s"%(p.id, pars.get(p.id, p.default)))
@@ -549,9 +549,9 @@ def parlist(model_info, pars, is2d):
             nsigma=pars.get(p.id+"_pd_nsgima", 3.),
             pdtype=pars.get(p.id+"_pd_type", 'gaussian'),
             relative_pd=p.relative_pd,
-            M0=pars.get('M0:'+p.id, 0.),
-            mphi=pars.get('mphi:'+p.id, 0.),
-            mtheta=pars.get('mtheta:'+p.id, 0.),
+            M0=pars.get(p.id+'_M0', 0.),
+            mphi=pars.get(p.id+'_mphi', 0.),
+            mtheta=pars.get(p.id+'_mtheta', 0.),
         )
         lines.append(_format_par(p.name, **fields))
         magnetic = magnetic or fields['M0'] != 0.
@@ -617,13 +617,13 @@ def suppress_magnetism(pars, suppress=True):
     pars = pars.copy()
     if suppress:
         for p in pars:
-            if p.startswith("M0:"):
+            if p.endswith("_M0"):
                 pars[p] = 0
     else:
         any_mag = False
         first_mag = None
         for p in pars:
-            if p.startswith("M0:"):
+            if p.endswith("_M0"):
                 any_mag |= (pars[p] != 0)
                 if first_mag is None:
                     first_mag = p

--- a/sasmodels/convert.py
+++ b/sasmodels/convert.py
@@ -164,7 +164,25 @@ def _conversion_target(model_name, version=(3, 1, 2)):
 def _hand_convert(name, oldpars, version=(3, 1, 2)):
     if version == (3, 1, 2):
         oldpars = _hand_convert_3_1_2_to_4_1(name, oldpars)
+    if version < (4, 2, 0):
+        oldpars = _rename_magnetic_pars(oldpars)
     return oldpars
+
+def _rename_magnetic_pars(pars):
+    """
+    Change from M0:par to par_M0, etc.
+    """
+    keys = list(pars.items())
+    for k in keys:
+        if k.startswith('M0:'):
+            pars[k[3:]+'_M0'] = pars.pop(k)
+        elif k.startswith('mtheta:'):
+            pars[k[7:]+'_mtheta'] = pars.pop(k)
+        elif k.startswith('mphi:'):
+            pars[k[5:]+'_mphi'] = pars.pop(k)
+        elif k.startswith('up:'):
+            pars['up_'+k[3:]] = pars.pop(k)
+    return pars
 
 def _hand_convert_3_1_2_to_4_1(name, oldpars):
     if name == 'core_shell_parallelepiped':

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -465,7 +465,7 @@ class ParameterTable(object):
                           for p in self.kernel_parameters)
         self.is_asymmetric = any(p.name == 'psi' for p in self.kernel_parameters)
         self.magnetism_index = [k for k, p in enumerate(self.call_parameters)
-                                if p.id.startswith('M0:')]
+                                if p.id.endswith('_M0')]
 
         self.pd_1d = set(p.name for p in self.call_parameters
                          if p.polydisperse and p.type not in ('orientation', 'magnetic'))
@@ -585,21 +585,21 @@ class ParameterTable(object):
         # Add the magnetic parameters to the end of the call parameter list.
         if self.nmagnetic > 0:
             full_list.extend([
-                Parameter('up:frac_i', '', 0., [0., 1.],
+                Parameter('up_frac_i', '', 0., [0., 1.],
                           'magnetic', 'fraction of spin up incident'),
-                Parameter('up:frac_f', '', 0., [0., 1.],
+                Parameter('up_frac_f', '', 0., [0., 1.],
                           'magnetic', 'fraction of spin up final'),
-                Parameter('up:angle', 'degrees', 0., [0., 360.],
+                Parameter('up_angle', 'degrees', 0., [0., 360.],
                           'magnetic', 'spin up angle'),
             ])
             slds = [p for p in full_list if p.type == 'sld']
             for p in slds:
                 full_list.extend([
-                    Parameter('M0:'+p.id, '1e-6/Ang^2', 0., [-np.inf, np.inf],
+                    Parameter(p.id+'_M0', '1e-6/Ang^2', 0., [-np.inf, np.inf],
                               'magnetic', 'magnetic amplitude for '+p.description),
-                    Parameter('mtheta:'+p.id, 'degrees', 0., [-90., 90.],
+                    Parameter(p.id+'_mtheta', 'degrees', 0., [-90., 90.],
                               'magnetic', 'magnetic latitude for '+p.description),
-                    Parameter('mphi:'+p.id, 'degrees', 0., [-180., 180.],
+                    Parameter(p.id+'_mphi', 'degrees', 0., [-180., 180.],
                               'magnetic', 'magnetic longitude for '+p.description),
                 ])
         #print("call parameters", full_list)
@@ -639,8 +639,8 @@ class ParameterTable(object):
         early, and rerender the table when it is changed.
 
         Parameters marked as sld will automatically have a set of associated
-        magnetic parameters (m0:p, mtheta:p, mphi:p), as well as polarization
-        information (up:theta, up:frac_i, up:frac_f).
+        magnetic parameters (p_M0, p_mtheta, p_mphi), as well as polarization
+        information (up_theta, up_frac_i, up_frac_f).
         """
         # control parameters go first
         control = [p for p in self.kernel_parameters if p.is_control]
@@ -667,9 +667,9 @@ class ParameterTable(object):
             """add the named parameter, and related magnetic parameters if any"""
             result.append(expanded_pars[name])
             if is2d:
-                for tag in 'M0:', 'mtheta:', 'mphi:':
-                    if tag+name in expanded_pars:
-                        result.append(expanded_pars[tag+name])
+                for tag in '_M0', '_mtheta', '_mphi':
+                    if name+tag in expanded_pars:
+                        result.append(expanded_pars[name+tag])
 
         # Gather the user parameters in order
         result = control + self.COMMON
@@ -702,11 +702,11 @@ class ParameterTable(object):
             else:
                 append_group(p.id)
 
-        if is2d and 'up:angle' in expanded_pars:
+        if is2d and 'up_angle' in expanded_pars:
             result.extend([
-                expanded_pars['up:frac_i'],
-                expanded_pars['up:frac_f'],
-                expanded_pars['up:angle'],
+                expanded_pars['up_frac_i'],
+                expanded_pars['up_frac_f'],
+                expanded_pars['up_angle'],
             ])
 
         return result

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -883,7 +883,7 @@ def test_old_name():
 def magnetic_demo():
     Model = _make_standard_model('sphere')
     model = Model()
-    model.setParam('M0:sld', 8)
+    model.setParam('sld_M0', 8)
     q = np.linspace(-0.35, 0.35, 500)
     qx, qy = np.meshgrid(q, q)
     result = model.calculate_Iq(qx.flatten(), qy.flatten())


### PR DESCRIPTION
This patch renames the magnetic parameters to not use colon in the name, and thus fixes ticket 1188, allowing users to change the model when the model contains magnetic parameters.

It also converts saved models.