### PR TITLE
supply intermediate results (Q,I(Q)) for mixture as well as product

### DIFF
--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -860,6 +860,7 @@ def run_models(opts, verbose=False):
             print("%s t=%.2f ms, intensity=%.0f"
                   % (base.engine, base_time, base_value.sum()))
         _show_invalid(base_data, base_value)
+        #if base.results is not None: print(base.results())
     except ImportError:
         traceback.print_exc()
 

--- a/sasmodels/direct_model.py
+++ b/sasmodels/direct_model.py
@@ -286,6 +286,7 @@ class DataMixin(object):
         self._kernel = None
         self.Iq, self.dIq, self.index = Iq, dIq, index
         self.resolution = res
+        self.results = None  # type: Optional[Callable[[], OrderedDict]
 
     def _set_data(self, Iq, noise=None):
         # type: (np.ndarray, Optional[float]) -> None
@@ -334,6 +335,7 @@ class DataMixin(object):
         pars['background'] = 0.
 
         Iq_calc = call_kernel(self._kernel, pars, cutoff=cutoff)
+        self.results = getattr(self._kernel, 'results', None)
         # Storing the calculated Iq values so that they can be plotted.
         # Only applies to oriented USANS data for now.
         # TODO: extend plotting of calculate Iq to other measurement types

--- a/sasmodels/product.py
+++ b/sasmodels/product.py
@@ -299,7 +299,7 @@ def _intermediates(
     The result may be an array or a float.
     """
     parts = OrderedDict()
-    parts["P(Q)"] = (Q, scale*F2)
+    parts["P(Q)"] = (Q, scale*Fsq)
     if P_intermediate is not None:
         parts["P(Q) parts"] = P_intermediate()
     parts["volume"] = volume
@@ -307,9 +307,9 @@ def _intermediates(
     parts["radius_effective"] = radius_effective
     parts["S(Q)"] = (Q, S)
     if beta_mode:
-        parts["beta(Q)"] = (Q, F1**2 / F2)
-        parts["S_eff(Q)"] = (Q, 1 + (F1**2 / F2)*(S-1))
-        #parts["I(Q)", scale*(F2 + (F1**2)*(S-1)) + bg
+        parts["beta(Q)"] = (Q, F**2 / Fsq)
+        parts["S_eff(Q)"] = (Q, 1 + (F**2 / Fsq)*(S-1))
+        #parts["I(Q)", scale*(Fsq + (F**2)*(S-1)) + bg
     return parts
 
 class ProductModel(KernelModel):

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -682,8 +682,8 @@ class SasviewModel(object):
                 _, lazy_results = self._calculate_Iq(qx)
                 # for compatibility with sasview 4.x
                 results = lazy_results()
-                pq_data = results.get("P(Q)")
-                sq_data = results.get("S(Q)")
+                pq_data = results.get("P(Q)")[1]
+                sq_data = results.get("S(Q)")[1]
                 return pq_data, sq_data
         else:
             return None


### PR DESCRIPTION
Refs SasView/sasview#1301.

This supplies intermediates with Q, I(Q) for mixture and product models as a hierarchical ordered dictionary.  Q may be [q] or [qx, qy].  Includes scalar radius_effective in product results.

This patch needs to be coordinated with the Qt GUI version.  Modify as needed for the needs of Qt, while preserving the interface to Sasview.calc_composition_models.