### PR TITLE
sasmodels-105 barbell and capped cylinder docs

### DIFF
--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -952,9 +952,9 @@ def main():
     parser.add_argument('-d', '--dim', type=int, default=1,
                         help='dimension 1 or 2')
     parser.add_argument('-m', '--mesh', type=int, default=100,
-                        help='number of mesh points')
+                        help='number of mesh points in the computed scattering')
     parser.add_argument('-s', '--samples', type=int, default=5000,
-                        help="number of sample points")
+                        help="number of sample points in the Monte Carlo estimate")
     parser.add_argument('-q', '--qmax', type=float, default=0.5,
                         help='max q')
     parser.add_argument('-v', '--view', type=str, default='0,0,0',

--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -450,7 +450,7 @@ def _calc_Pr_uniform(r, rho, points):
     return Pr
 
     # Can get an additional 2x by going to C.  Cuda/OpenCL will allow even
-    # more speedup, though still bounded by the n^2 cose.
+    # more speedup, though still bounded by the O(n^2) cost.
     """
 void pdfcalc(int n, const double *pts, const double *rho,
 	     int nPr, double *Pr, double rstep)

--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -991,4 +991,11 @@ def main():
 
 
 if __name__ == "__main__":
+    # Make sure sasmodels in on the path
+    try:
+        import sasmodels
+    except ImportError:
+        import sys
+        from os.path import realpath, dirname, join as joinpath
+        sys.path.insert(0, dirname(dirname(realpath(__file__))))
     main()

--- a/sasmodels/models/barbell.c
+++ b/sasmodels/models/barbell.c
@@ -1,13 +1,13 @@
 #define INVALID(v) (v.radius_bell < v.radius)
 
-//barbell kernel - same as dumbell
+//barbell kernel - same as dumbbell
 static double
 _bell_kernel(double qab, double qc, double h, double radius_bell,
              double half_length)
 {
     // translate a point in [-1,1] to a point in [lower,upper]
     const double upper = 1.0;
-    const double lower = h/radius_bell;
+    const double lower = -h/radius_bell;
     const double zm = 0.5*(upper-lower);
     const double zb = 0.5*(upper+lower);
 
@@ -19,7 +19,7 @@ _bell_kernel(double qab, double qc, double h, double radius_bell,
     //    m = q R cos(alpha)
     //    b = q(L/2-h) cos(alpha)
     const double m = radius_bell*qc; // cos argument slope
-    const double b = (half_length-h)*qc; // cos argument intercept
+    const double b = (half_length+h)*qc; // cos argument intercept
     const double qab_r = radius_bell*qab; // Q*R*sin(theta)
     double total = 0.0;
     for (int i = 0; i < GAUSS_N; i++){
@@ -53,20 +53,23 @@ form_volume(double radius_bell,
     double length)
 {
     // bell radius should never be less than radius when this is called
-    const double hdist = sqrt(square(radius_bell) - square(radius));
-    const double p1 = 2.0/3.0*cube(radius_bell);
-    const double p2 = square(radius_bell)*hdist;
-    const double p3 = cube(hdist)/3.0;
-
-    return M_PI*square(radius)*length + 2.0*M_PI*(p1+p2-p3);
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double slice = M_PI*(square(radius_bell)*h - cube(h)/3.0);
+    const double hemisphere = 2.0*M_PI/3.0*cube(radius_bell);
+    const double rod = M_PI*square(radius)*length;
+    // h > 0 so slice is added to hemisphere
+    return rod + 2.0*(hemisphere + slice);
 }
 
 static double
 radius_from_excluded_volume(double radius_bell, double radius, double length)
 {
-    const double hdist = sqrt(square(radius_bell) - square(radius));
-    const double length_tot = length + 2.0*(hdist+ radius);
-    return 0.5*cbrt(0.75*radius_bell*(2.0*radius_bell*length_tot + (radius_bell + length_tot)*(M_PI*radius_bell + length_tot)));
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double length_tot = length + 2.0*(radius + h);
+    // Use cylinder excluded volume with length' = length + caps and
+    // radius' = bell radius since the bell is bigger than the cylinder.
+    return 0.5*cbrt(0.75*radius_bell*(2.0*radius_bell*length_tot
+           + (radius_bell + length_tot)*(M_PI*radius_bell + length_tot)));
 }
 
 static double
@@ -79,8 +82,9 @@ radius_from_volume(double radius_bell, double radius, double length)
 static double
 radius_from_totallength(double radius_bell, double radius, double length)
 {
-    const double hdist = sqrt(square(radius_bell) - square(radius));
-    return 0.5*length + hdist + radius_bell;
+    const double h = sqrt(square(radius_bell) - square(radius));
+    const double half_length = 0.5*length;
+    return half_length + radius_bell + h;
 }
 
 static double
@@ -105,7 +109,7 @@ static void
 Fq(double q,double *F1, double *F2, double sld, double solvent_sld,
     double radius_bell, double radius, double length)
 {
-    const double h = -sqrt(radius_bell*radius_bell - radius*radius);
+    const double h = sqrt(square(radius_bell) - square(radius));
     const double half_length = 0.5*length;
 
     // translate a point in [-1,1] to a point in [0, pi/2]
@@ -114,16 +118,19 @@ Fq(double q,double *F1, double *F2, double sld, double solvent_sld,
     double total_F1 = 0.0;
     double total_F2 = 0.0;
     for (int i = 0; i < GAUSS_N; i++){
-        const double alpha= GAUSS_Z[i]*zm + zb;
-        double sin_alpha, cos_alpha; // slots to hold sincos function output
-        SINCOS(alpha, sin_alpha, cos_alpha);
-        const double Aq = _fq(q*sin_alpha, q*cos_alpha, h, radius_bell, radius, half_length);
-        total_F1 += GAUSS_W[i] * Aq * sin_alpha;
-        total_F2 += GAUSS_W[i] * Aq * Aq * sin_alpha;
+        const double theta = GAUSS_Z[i]*zm + zb;
+        double sin_theta, cos_theta; // slots to hold sincos function output
+        SINCOS(theta, sin_theta, cos_theta);
+        const double qab = q*sin_theta;
+        const double qc = q*cos_theta;
+        const double Aq = _fq(qab, qc, h, radius_bell, radius, half_length);
+        // scale by sin_theta for spherical coord integration
+        total_F1 += GAUSS_W[i] * Aq * sin_theta;
+        total_F2 += GAUSS_W[i] * Aq * Aq * sin_theta;
     }
     // translate dx in [-1,1] to dx in [lower,upper]
-    const double form_avg = total_F1*zm;
-    const double form_squared_avg = total_F2*zm;
+    const double form_avg = total_F1 * zm;
+    const double form_squared_avg = total_F2 * zm;
 
     //Contrast
     const double s = (sld - solvent_sld);
@@ -136,7 +143,7 @@ Iqac(double qab, double qc,
     double sld, double solvent_sld,
     double radius_bell, double radius, double length)
 {
-    const double h = -sqrt(square(radius_bell) - square(radius));
+    const double h = sqrt(square(radius_bell) - square(radius));
     const double Aq = _fq(qab, qc, h, radius_bell, radius, 0.5*length);
 
     // Multiply by contrast^2 and convert to cm-1

--- a/sasmodels/models/barbell.py
+++ b/sasmodels/models/barbell.py
@@ -12,8 +12,8 @@ the details of the geometry and restrictions on parameter values.
 
     Barbell geometry, where $r$ is *radius*, $R$ is *radius_bell* and
     $L$ is *length*. Since the end cap radius $R \geq r$ and by definition
-    for this geometry $h < 0$, $h$ is then defined by $r$ and $R$ as
-    $h = - \sqrt{R^2 - r^2}$
+    for this geometry $h \ge 0$, $h$ is then defined by $r$ and $R$ as
+    $h = \sqrt{R^2 - r^2}$
 
 The scattered intensity $I(q)$ is calculated as
 
@@ -48,18 +48,16 @@ The volume of the barbell is
 
     V = \pi r_c^2 L + 2\pi\left(\tfrac23R^3 + R^2h-\tfrac13h^3\right)
 
-
 and its radius of gyration is
 
 .. math::
 
-    R_g^2 =&\ \left[ \tfrac{12}{5}R^5
-        + R^4\left(6h+\tfrac32 L\right)
-        + R^2\left(4h^2 + L^2 + 4Lh\right)
-        + R^2\left(3Lh^2 + \tfrac32 L^2h\right) \right. \\
-        &\ \left. + \tfrac25 h^5 - \tfrac12 Lh^4 - \tfrac12 L^2h^3
-        + \tfrac14 L^3r^2 + \tfrac32 Lr^4 \right]
-        \left( 4R^3 6R^2h - 2h^3 + 3r^2L \right)^{-1}
+    R_g^2 =&\ \left[ \tfrac{12}{5}R^4
+        + R^3\left(3L + \tfrac{18}{5} h\right)
+        + R^2\left(L^2 + Lh + \tfrac25 h^2\right)
+        + R\left(\tfrac14 L^3 + \tfrac12 L^2h - Lh^2\right) \right. \\
+        &\ \left. + Lh^4 - \tfrac12 L^2h^3 - \tfrac14 L^3h + \tfrac25 h^4\right]
+        \left( 4R^2 + 3LR + 2Rh - 3Lh - 2h^2\right)^{-1}
 
 .. note::
     The requirement that $R \geq r$ is not enforced in the model! It is

--- a/sasmodels/models/barbell.py
+++ b/sasmodels/models/barbell.py
@@ -152,7 +152,8 @@ demo = dict(scale=1, background=0,
             phi_pd=15, phi_pd_n=0,
            )
 q = 0.1
-# april 6 2017, rkh add unit tests, NOT compared with any other calc method, assume correct!
+# 2017-04-06: rkh add unit tests, NOT compared with any other calc method, assume correct!
+# 2019-05-17: pak added barbell/capped cylinder to realspace sampling tests
 qx = q*cos(pi/6.0)
 qy = q*sin(pi/6.0)
 tests = [

--- a/sasmodels/models/capped_cylinder.c
+++ b/sasmodels/models/capped_cylinder.c
@@ -14,7 +14,7 @@ _cap_kernel(double qab, double qc, double h, double radius_cap,
 {
     // translate a point in [-1,1] to a point in [lower,upper]
     const double upper = 1.0;
-    const double lower = h/radius_cap; // integral lower bound
+    const double lower = -h/radius_cap; // integral lower bound
     const double zm = 0.5*(upper-lower);
     const double zb = 0.5*(upper+lower);
 
@@ -26,7 +26,7 @@ _cap_kernel(double qab, double qc, double h, double radius_cap,
     //    m = q R cos(theta)
     //    b = q(L/2-h) cos(theta)
     const double m = radius_cap*qc; // cos argument slope
-    const double b = (half_length-h)*qc; // cos argument intercept
+    const double b = (half_length+h)*qc; // cos argument intercept
     const double qab_r = radius_cap*qab; // Q*R*sin(theta)
     double total = 0.0;
     for (int i=0; i<GAUSS_N; i++) {
@@ -57,38 +57,23 @@ static double
 form_volume(double radius, double radius_cap, double length)
 {
     // cap radius should never be less than radius when this is called
-
-    // Note: volume V = 2*V_cap + V_cyl
-    //
-    // V_cyl = pi r_cyl^2 L
-    // V_cap = 1/6 pi h_c (3 r_cyl^2 + h_c^2) = 1/3 pi h_c^2 (3 r_cap - h_c)
-    //
-    // The docs for capped cylinder give the volume as:
-    //    V = pi r^2 L + 2/3 pi (R-h)^2 (2R + h)
-    // where r_cap=R and h = R - h_c.
-    //
-    // The first part is clearly V_cyl.  The second part requires some work:
-    //    (R-h)^2 => h_c^2
-    //    (2R+h) => 2R+ h_c-h_c + h => 2R + (R-h)-h_c + h => 3R-h_c
-    // And so:
-    //    2/3 pi (R-h)^2 (2R + h) => 2/3 pi h_c^2 (3 r_cap - h_c)
-    // which is 2 V_cap, using the second form above.
-    //
-    // In this function we are going to use the first form of V_cap
-    //
-    //      V = V_cyl + 2 V_cap
-    //        = pi r^2 L + pi hc (r^2 + hc^2/3)
-    //        = pi (r^2 (L+hc) + hc^3/3)
-    const double hc = radius_cap - sqrt(radius_cap*radius_cap - radius*radius);
-    return M_PI*(radius*radius*(length+hc) + hc*hc*hc/3.0);
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double slice = M_PI*(square(radius_cap)*h - cube(h)/3.0);
+    const double hemisphere = 2.0*M_PI/3.0*cube(radius_cap);
+    const double rod = M_PI*square(radius)*length;
+    // h < 0 so slice is subtracted from hemisphere
+    return rod + 2.0*(hemisphere + slice);
 }
 
 static double
 radius_from_excluded_volume(double radius, double radius_cap, double length)
 {
-    const double hc = radius_cap - sqrt(radius_cap*radius_cap - radius*radius);
-    const double length_tot = length + 2.0*hc;
-    return 0.5*cbrt(0.75*radius*(2.0*radius*length_tot + (radius + length_tot)*(M_PI*radius + length_tot)));
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double length_tot = length + 2.0*(radius_cap + h);
+    // Use cylinder excluded volume with length' = length + caps and
+    // radius' = cylinder radius since the lens is smaller than the cylinder.
+    return 0.5*cbrt(0.75*radius*(2.0*radius*length_tot
+           + (radius + length_tot)*(M_PI*radius + length_tot)));
 }
 
 static double
@@ -101,8 +86,9 @@ radius_from_volume(double radius, double radius_cap, double length)
 static double
 radius_from_totallength(double radius, double radius_cap, double length)
 {
-    const double hc = radius_cap - sqrt(radius_cap*radius_cap - radius*radius);
-    return 0.5*length + hc;
+    const double h = -sqrt(square(radius_cap) - square(radius));
+    const double half_length = 0.5*length;
+    return half_length + radius_cap - h;
 }
 
 static double
@@ -127,7 +113,7 @@ static void
 Fq(double q,double *F1, double *F2, double sld, double solvent_sld,
     double radius, double radius_cap, double length)
 {
-    const double h = sqrt(radius_cap*radius_cap - radius*radius);
+    const double h = -sqrt(square(radius_cap) - square(radius));
     const double half_length = 0.5*length;
 
     // translate a point in [-1,1] to a point in [0, pi/2]
@@ -162,7 +148,7 @@ Iqac(double qab, double qc,
     double sld, double solvent_sld, double radius,
     double radius_cap, double length)
 {
-    const double h = sqrt(radius_cap*radius_cap - radius*radius);
+    const double h = -sqrt(square(radius_cap) - square(radius));
     const double Aq = _fq(qab, qc, h, radius_cap, radius, 0.5*length);
 
     // Multiply by contrast^2 and convert to cm-1

--- a/sasmodels/models/capped_cylinder.py
+++ b/sasmodels/models/capped_cylinder.py
@@ -173,7 +173,8 @@ demo = dict(scale=1, background=0,
             theta_pd=15, theta_pd_n=45,
             phi_pd=15, phi_pd_n=1)
 q = 0.1
-# april 6 2017, rkh add unit tests, NOT compared with any other calc method, assume correct!
+# 2017-04-06: rkh add unit tests, NOT compared with any other calc method, assume correct!
+# 2019-05-17: pak added barbell/capped cylinder to realspace sampling tests
 qx = q*cos(pi/6.0)
 qy = q*sin(pi/6.0)
 tests = [

--- a/sasmodels/models/capped_cylinder.py
+++ b/sasmodels/models/capped_cylinder.py
@@ -11,10 +11,10 @@ of the geometry and restrictions on parameter values.
 
 .. figure:: img/capped_cylinder_geometry.jpg
 
-    Capped cylinder geometry, where $r$ is *radius*, $R$ is *bell_radius* and
+    Capped cylinder geometry, where $r$ is *radius*, $R$ is *radius_cap* and
     $L$ is *length*. Since the end cap radius $R \geq r$ and by definition
-    for this geometry $h < 0$, $h$ is then defined by $r$ and $R$ as
-    $h = - \sqrt{R^2 - r^2}$
+    for this geometry $h \le 0$, $h$ is then defined by $r$ and $R$ as
+    $h = -\sqrt{R^2 - r^2}$
 
 The scattered intensity $I(q)$ is calculated as
 
@@ -47,8 +47,7 @@ The volume of the capped cylinder is (with $h$ as a positive value here)
 
 .. math::
 
-    V = \pi r_c^2 L + \tfrac{2\pi}{3}(R-h)^2(2R + h)
-
+    V = \pi r_c^2 L + 2\pi\left(\tfrac23R^3 + R^2h - \tfrac13h^3\right)
 
 and its radius of gyration is
 
@@ -56,11 +55,11 @@ and its radius of gyration is
 
     R_g^2 =&\ \left[ \tfrac{12}{5}R^5
         + R^4\left(6h+\tfrac32 L\right)
-        + R^2\left(4h^2 + L^2 + 4Lh\right)
+        + R^3\left(4h^2 + L^2 + 4Lh\right)
         + R^2\left(3Lh^2 + \tfrac32 L^2h\right) \right. \\
         &\ \left. + \tfrac25 h^5 - \tfrac12 Lh^4 - \tfrac12 L^2h^3
         + \tfrac14 L^3r^2 + \tfrac32 Lr^4 \right]
-        \left( 4R^3 6R^2h - 2h^3 + 3r^2L \right)^{-1}
+        \left( 4R^3 + 6R^2h - 2h^3 + 3r^2L \right)^{-1}
 
 
 .. note::

--- a/sasmodels/models/cylinder.c
+++ b/sasmodels/models/cylinder.c
@@ -15,7 +15,8 @@ _fq(double qab, double qc, double radius, double length)
 static double
 radius_from_excluded_volume(double radius, double length)
 {
-    return 0.5*cbrt(0.75*radius*(2.0*radius*length + (radius + length)*(M_PI*radius + length)));
+    return 0.5*cbrt(0.75*radius*(2.0*radius*length
+           + (radius + length)*(M_PI*radius + length)));
 }
 
 static double


### PR DESCRIPTION
See #105.

Updated barbell and capped cylinder so that equations in code and docs track the Kaye reference more closely.

Cross-checked the curves against real-space Monte Carlo sampling using Pr inversion.

Note that the addendum paper suggests that the Rg calculation for the capped cylinder generalizes the Rg derived for the barbell, and that it can be used for both.  I didn't check that this was the case, and instead set the Rg for barbell to that from the original paper and Rg for the capped cylinder to that from the addendum.
