### PR TITLE
Monte Carlo simulation of triaxial ellipsoid

### DIFF
--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -713,6 +713,34 @@ def build_csbox(a=10, b=20, c=30, da=1, db=2, dc=3, slda=1, sldb=2, sldc=3, sld_
                                             slda, sldb, sldc, sld_core, view=view)
     return shape, fn, fn_xy
 
+def build_triell(ra=125, rb=200, rc=50, rho=2):
+    shape = TriaxialEllipsoid(ra, rb, rc, rho)
+    fn, fn_xy = wrap_sasmodel(
+        'triaxial_ellipsoid',
+        scale=1,
+        background=0,
+        radius_equat_minor=ra,
+        radius_equat_major=rb,
+        radius_polar=rc,
+        sld=rho,
+        sld_solvent=0,
+    )
+    return shape, fn, fn_xy
+
+def build_ellip(rab=125, rc=50, rho=2):
+    shape = TriaxialEllipsoid(rab, rab, rc, rho)
+    fn, fn_xy = wrap_sasmodel(
+        'ellipsoid',
+        scale=1,
+        background=0,
+        radius_equatorial=rab,
+        radius_polar=rc,
+        sld=rho,
+        sld_solvent=0,
+    )
+    return shape, fn, fn_xy
+
+
 def build_ellcyl(ra=25, rb=50, length=125, rho=2.):
     shape = EllipticalCylinder(ra, rb, length, rho)
     fn, fn_xy = wrap_sasmodel(
@@ -768,6 +796,8 @@ def build_cubic_lattice(shape, nx=1, ny=1, nz=1, dx=2, dy=2, dz=2,
 SHAPE_FUNCTIONS = OrderedDict([
     ("cyl", build_cylinder),
     ("ellcyl", build_ellcyl),
+    ("ellip", build_ellip),
+    ("triell", build_triell),
     ("sphere", build_sphere),
     ("box", build_box),
     ("csbox", build_csbox),


### PR DESCRIPTION
Closes #296.

Add ellipsoid and triaxial ellipsoid to explore/realspace monte carlo simulations so we can verify the calculations against a non-analytic method.

The bug described in #296 was fixed by [68dd6a95](https://github.com/SasView/sasmodels/commit/68dd6a95) on 2017-03-22, but the ticket was not closed.  I'm closing the ticket now since the fix does not depend on this PR.

