### PR TITLE
Permit parallel doc build

### DIFF
--- a/doc/genmodel.py
+++ b/doc/genmodel.py
@@ -132,8 +132,7 @@ def copy_if_newer(src, dst):
     import shutil
     if not exists(dst):
         path = dirname(dst)
-        if not exists(path):
-            os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
         shutil.copy2(src, dst)
     elif getmtime(src) > getmtime(dst):
         shutil.copy2(src, dst)


### PR DESCRIPTION
`genmodel.py` does a lot of work but is easily run in parallel by make. The race condition in checking for and creating the output directory needs to be handled, however. The `exists()` check could actually be removed with this change.

Useful for speeding up the documentation build on travis, for instance.
