### PR TITLE
Build documentation on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ matrix:
     language: generic
     env:
     - PY=3.7
-branches:
-  only:
-  - master
 addons:
   apt:
     packages: opencl-headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   - os: linux
     env:
     - PY=3.7
+    - BUILDDOC=1
   - os: osx
     language: generic
     env:
@@ -44,7 +45,7 @@ script:
 #- python -m sasmodels.model_test -v dll all
 #- python -m pytest -v --cache-clear
 - python setup.py test --pytest-args -v
-- make -j 4 -C doc html
+- if [ -n "$BUILDDOC" ]; then make -j 4 -C doc html; fi
 before_deploy:
 - echo -e "Host danse.chem.utk.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 - hash -r
 - conda update --yes conda
 - conda info -a
-- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools pytest
+- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools pytest sphinx
 install:
 - pip install bumps
 - pip install unittest-xml-reporting tinycc
@@ -44,6 +44,7 @@ script:
 #- python -m sasmodels.model_test -v dll all
 #- python -m pytest -v --cache-clear
 - python setup.py test --pytest-args -v
+- make -j 4 -C doc html
 before_deploy:
 - echo -e "Host danse.chem.utk.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ matrix:
   include:
   - os: linux
     env:
-    - PY=2.7
-    #- DEPLOY=True
+    - PY=3.6
   - os: linux
     env:
     - PY=3.7
   - os: osx
     language: generic
     env:
-    - PY=2.7
+    - PY=3.6
   - os: osx
     language: generic
     env:


### PR DESCRIPTION
In the interests of catching errors in the rst, `genmodel.py`, `conf.py` etc, building the documentation on travis-ci would be beneficial. The implementation would look something like this.

Thoughts?

(Dropping 2.7 is due to #373, dropping the restriction to the master branch is so I could actually test it; and perhaps it makes sense to not restrict CI so that code can go through CI before opening a PR?)