### PR TITLE
Doc fixes for references and formulae

### DIFF
--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -11,7 +11,7 @@ create your own models. This document describes how to create plugin models
 from first principles.
 
 If you are using SasView and simply want to combine existing models into a new
-plugin, see the :ref:`Sum|Multi(p1,p2)` tool instead.
+plugin, see the :ref:`Add/Multiply Models` tool instead.
 
 Models can be of three types:
 

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -217,8 +217,8 @@ For example::
     References
     ----------
 
-    A Guinier, G Fournet, *Small-Angle Scattering of X-Rays*,
-    John Wiley and Sons, New York, (1955)
+    #. A Guinier, G Fournet, *Small-Angle Scattering of X-Rays*,
+       John Wiley and Sons, New York, (1955)
     """
 
 This is where the FULL documentation for the model goes (to be picked up by

--- a/sasmodels/models/_spherepy.py
+++ b/sasmodels/models/_spherepy.py
@@ -5,7 +5,7 @@ the :ref:`magnetism` documentation.
 Definition
 ----------
 
-The 1D scattering intensity is calculated in the following way (Guinier, 1955)
+The 1D scattering intensity is calculated in the following way [Guinier1955]_
 
 .. math::
 
@@ -35,8 +35,8 @@ to the output of the software provided by the NIST (Kline, 2006).
 References
 ----------
 
-A Guinier and G. Fournet, *Small-Angle Scattering of X-Rays*,
-John Wiley and Sons, New York, (1955)
+.. [Guinier1955] A Guinier and G. Fournet, *Small-Angle Scattering of X-Rays*,
+   John Wiley and Sons, New York, (1955)
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/adsorbed_layer.py
+++ b/sasmodels/models/adsorbed_layer.py
@@ -40,12 +40,12 @@ other shape models, no volume normalization is applied to this model (the
 calculation is exact).
 
 The code for this model is based originally on a a fortran implementation by
-Steve King at ISIS in the SANDRA package c. 1990.
+Steve King at ISIS in the SANDRA package c. 1990 [#King2002]_.
 
 References
 ----------
 
-.. [#] S King, P Griffiths, J Hone, and T Cosgrove, *SANS from Adsorbed Polymer
+.. [#King2002] S King, P Griffiths, J Hone, and T Cosgrove, *SANS from Adsorbed Polymer
    Layers*, *Macromol. Symp.*, 190 (2002) 33-42.
 
 Authorship and Verification

--- a/sasmodels/models/barbell.py
+++ b/sasmodels/models/barbell.py
@@ -73,10 +73,12 @@ The 2D scattering intensity is calculated similar to the 2D cylinder model.
 References
 ----------
 
-.. [#] H Kaya, *J. Appl. Cryst.*, 37 (2004) 223-230
-.. [#] H Kaya and N R deSouza, *J. Appl. Cryst.*, 37 (2004) 508-509 (addenda
-   and errata)
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#. H Kaya, *J. Appl. Cryst.*, 37 (2004) 223-230
+
+#. H Kaya and N R deSouza, *J. Appl. Cryst.*, 37 (2004) 508-509
+   (addenda and errata)
+
+#. L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/barbell.py
+++ b/sasmodels/models/barbell.py
@@ -3,7 +3,7 @@ Definition
 ----------
 
 Calculates the scattering from a barbell-shaped cylinder.  Like
-:ref:`capped-cylinder`, this is a sphereocylinder with spherical end
+:ref:`capped-cylinder`, this is a spherocylinder with spherical end
 caps that have a radius larger than that of the cylinder, but with the center
 of the end cap radius lying outside of the cylinder. See the diagram for
 the details of the geometry and restrictions on parameter values.

--- a/sasmodels/models/bcc_paracrystal.py
+++ b/sasmodels/models/bcc_paracrystal.py
@@ -23,8 +23,8 @@ primary particle, $V_\text{lattice}$ is a volume correction for the crystal
 structure, $P(q)$ is the form factor of the sphere (normalized), and $Z(q)$
 is the paracrystalline structure factor for a body-centered cubic structure.
 
-Equation (1) of the 1990 reference\ [#CIT1990]_ is used to calculate $Z(q)$,
-using equations (29)-(31) from the 1987 paper\ [#CIT1987]_ for $Z1$, $Z2$, and
+Equation (1) of the 1990 reference\ [#Matsuoka1990]_ is used to calculate $Z(q)$,
+using equations (29)-(31) from the 1987 paper\ [#Matsuoka1987]_ for $Z1$, $Z2$, and
 $Z3$.
 
 The lattice correction (the occupied volume of the lattice) for a
@@ -94,9 +94,9 @@ Note that we are not responsible for any incorrectness of the 2D model computati
 References
 ----------
 
-.. [#CIT1987] Hideki Matsuoka et. al. *Physical Review B*, 36 (1987) 1754-1765
+.. [#Matsuoka1987] Hideki Matsuoka et. al. *Physical Review B*, 36 (1987) 1754-1765
    (Original Paper)
-.. [#CIT1990] Hideki Matsuoka et. al. *Physical Review B*, 41 (1990) 3854 -3856
+.. [#Matsuoka1990] Hideki Matsuoka et. al. *Physical Review B*, 41 (1990) 3854 -3856
    (Corrections to FCC and BCC lattice structure calculation)
 
 Authorship and Verification

--- a/sasmodels/models/be_polyelectrolyte.py
+++ b/sasmodels/models/be_polyelectrolyte.py
@@ -84,11 +84,13 @@ Once better validation has been performed this note will be removed.
 References
 ----------
 
+For further details, see [#Joanny1990]_, [#Moussaid1993]_, [#Raphael1990]_.
+
 .. [#Borue] V Y Borue, I Y Erukhimovich, *Macromolecules*, 21 (1988) 3240
-.. [#] J F Joanny, L Leibler, *Journal de Physique*, 51 (1990) 545
-.. [#] A Moussaid, F Schosseler, J P Munch, S Candau, *J. Journal de Physique
+.. [#Joanny1990] J F Joanny, L Leibler, *Journal de Physique*, 51 (1990) 545
+.. [#Moussaid1993] A Moussaid, F Schosseler, J P Munch, S Candau, *J. Journal de Physique
    II France*, 3 (1993) 573
-.. [#] E Raphael, J F Joanny, *Europhysics Letters*, 11 (1990) 179
+.. [#Raphael1990] E Raphael, J F Joanny, *Europhysics Letters*, 11 (1990) 179
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/binary_hard_sphere.py
+++ b/sasmodels/models/binary_hard_sphere.py
@@ -60,9 +60,10 @@ See the references for details.
 References
 ----------
 
-.. [#] N W Ashcroft and D C Langreth, *Physical Review*, 156 (1967) 685-692
+#. N W Ashcroft and D C Langreth, *Physical Review*, 156 (1967) 685-692
    [Errata found in *Phys. Rev.* 166 (1968) 934]
-.. [#] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
+
+#. S R Kline, *J Appl. Cryst.*, 39 (2006) 895
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/binary_hard_sphere.py
+++ b/sasmodels/models/binary_hard_sphere.py
@@ -47,7 +47,7 @@ wary of results for (total) volume fractions greater than approximately 40%.
 Depending on the size ratios or number fractions, the limit on total volume
 fraction may be lower.
 
-**NOTE 3:** The heavy arithmatic operations also mean that at present the
+**NOTE 3:** The heavy arithmetic operations also mean that at present the
 function is poorly behaved at very low qr.  In some cases very large qr may
 also be poorly behaved.  These should however be outside any useful region of
 qr.

--- a/sasmodels/models/capped_cylinder.py
+++ b/sasmodels/models/capped_cylinder.py
@@ -77,10 +77,12 @@ The 2D scattering intensity is calculated similar to the 2D cylinder model.
 References
 ----------
 
-.. [#] H Kaya, *J. Appl. Cryst.*, 37 (2004) 223-230
-.. [#] H Kaya and N-R deSouza, *J. Appl. Cryst.*, 37 (2004) 508-509 (addenda
-   and errata)
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#. H Kaya, *J. Appl. Cryst.*, 37 (2004) 223-230
+
+#. H Kaya and N R deSouza, *J. Appl. Cryst.*, 37 (2004) 508-509
+   (addenda and errata)
+
+#. L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_multi_shell.py
+++ b/sasmodels/models/core_multi_shell.py
@@ -27,15 +27,17 @@ orientation of the $\vec q$ vector which is defined as
 For information about polarised and magnetic scattering, see
 the :ref:`magnetism` documentation.
 
-Our model uses the form factor calculations implemented in a c-library provided
-by the NIST Center for Neutron Research (Kline, 2006) [#kline]_.
+Our model uses the form factor calculations implemented in a C-library provided
+by the NIST Center for Neutron Research [#Kline2006]_.
 
 References
 ----------
 
-.. [#] See the :ref:`core-shell-sphere` model documentation.
-.. [#kline] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
-.. [#] L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and
+Also see the :ref:`core-shell-sphere` model documentation and [#Feigin1987]_
+
+.. [#Kline2006] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
+
+.. [#Feigin1987] L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and
    Neutron Scattering*, Plenum Press, New York, 1987.
 
 Authorship and Verification

--- a/sasmodels/models/core_shell_bicelle.py
+++ b/sasmodels/models/core_shell_bicelle.py
@@ -84,12 +84,11 @@ use the c-library from NIST.
 References
 ----------
 
-.. [#] D Singh (2009). *Small angle scattering studies of self assembly in
+#. D Singh (2009). *Small angle scattering studies of self assembly in
    lipid mixtures*, John's Hopkins University Thesis (2009) 223-225. `Available
-   from Proquest <http://search.proquest.com/docview/304915826?accountid
-   =26379>`_
+   from Proquest <http://search.proquest.com/docview/304915826>`_
 
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_shell_bicelle_elliptical.py
+++ b/sasmodels/models/core_shell_bicelle_elliptical.py
@@ -3,7 +3,8 @@ Definition
 ----------
 
 This model provides the form factor for an elliptical cylinder with a
-core-shell scattering length density profile. Thus this is a variation
+core-shell scattering length density profile [#Onsager1949]_.
+Thus this is a variation
 of the core-shell bicelle model, but with an elliptical cylinder for the core.
 Outer shells on the rims and flat ends may be of different thicknesses and
 scattering length densities. The form factor is normalized by the total
@@ -98,7 +99,7 @@ Model verified using Monte Carlo simulation for 1D and 2D scattering.
 References
 ----------
 
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+.. [#Onsager1949] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
+++ b/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
@@ -3,7 +3,8 @@ Definition
 ----------
 
 This model provides the form factor for an elliptical cylinder with a
-core-shell scattering length density profile. Thus this is a variation
+core-shell scattering length density profile [#Onsager1949]_.
+Thus this is a variation
 of the core-shell bicelle model, but with an elliptical cylinder for the core.
 In this version the "rim" or "belt" does NOT extend the full length of
 the particle, but has the same length as the core. Outer shells on the
@@ -110,7 +111,7 @@ and angular dispersions  see :ref:`orientation` .
 References
 ----------
 
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+.. [#Onsager1949] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_shell_cylinder.py
+++ b/sasmodels/models/core_shell_cylinder.py
@@ -3,7 +3,7 @@ Definition
 ----------
 
 The output of the 2D scattering intensity function for oriented core-shell
-cylinders is given by (Kline, 2006 [#kline]_). The form factor is normalized
+cylinders is given by Kline [#Kline2006]_. The form factor is normalized
 by the particle volume. Note that in this model the shell envelops the entire
 core so that besides a "sleeve" around the core, the shell also provides two
 flat end caps of thickness = shell thickness. In other words the length of the
@@ -66,10 +66,13 @@ The $\theta$ and $\phi$ parameters are not used for the 1D output.
 Reference
 ---------
 
-.. [#] see, for example, Ian Livsey  J. Chem. Soc., Faraday Trans. 2, 1987,83,
-   1445-1452
-.. [#kline] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+See also Livsey [#Livsey1987]_ and Onsager [#Onsager1949]_.
+
+.. [#Livsey1987] I Livsey, *J. Chem. Soc., Faraday Trans. 2*, 83 (1987) 1445-1452
+
+.. [#Kline2006] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
+
+.. [#Onsager1949] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_shell_cylinder.py
+++ b/sasmodels/models/core_shell_cylinder.py
@@ -7,7 +7,7 @@ cylinders is given by Kline [#Kline2006]_. The form factor is normalized
 by the particle volume. Note that in this model the shell envelops the entire
 core so that besides a "sleeve" around the core, the shell also provides two
 flat end caps of thickness = shell thickness. In other words the length of the
-total cyclinder is the length of the core cylinder plus twice the thickness of
+total cylinder is the length of the core cylinder plus twice the thickness of
 the shell. If no end caps are desired one should use the
 :ref:`core-shell-bicelle` and set the thickness of the end caps (in this case
 the "thick_face") to zero.

--- a/sasmodels/models/core_shell_ellipsoid.py
+++ b/sasmodels/models/core_shell_ellipsoid.py
@@ -93,8 +93,9 @@ References
 ----------
 see for example:
 
-.. [#] Kotlarchyk, M.; Chen, S.-H. *J. Chem. Phys.*, 1983, 79, 2461
-.. [#] Berr, S. *J. Phys. Chem.*, 1987, 91, 4760
+#.  Kotlarchyk, M.; Chen, S.-H. *J. Chem. Phys.*, 1983, 79, 2461
+
+#.  Berr, S. *J. Phys. Chem.*, 1987, 91, 4760
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_shell_parallelepiped.py
+++ b/sasmodels/models/core_shell_parallelepiped.py
@@ -166,13 +166,13 @@ shape for non-uniform, non-overlapping sides.
 References
 ----------
 
-.. [#] P Mittelbach and G Porod, *Acta Physica Austriaca*, 14 (1961) 185-211
-    Equations (1), (13-14). (in German)
-.. [#] D Singh (2009). *Small angle scattering studies of self assembly in
+#. P Mittelbach and G Porod, *Acta Physica Austriaca*, 14 (1961) 185-211
+   Equations (1), (13-14). (in German)
+#. D Singh (2009). *Small angle scattering studies of self assembly in
    lipid mixtures*, Johns Hopkins University Thesis (2009) 223-225. `Available
    from Proquest <http://search.proquest.com/docview/304915826?accountid
    =26379>`_
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/core_shell_parallelepiped.py
+++ b/sasmodels/models/core_shell_parallelepiped.py
@@ -170,8 +170,7 @@ References
    Equations (1), (13-14). (in German)
 #. D Singh (2009). *Small angle scattering studies of self assembly in
    lipid mixtures*, Johns Hopkins University Thesis (2009) 223-225. `Available
-   from Proquest <http://search.proquest.com/docview/304915826?accountid
-   =26379>`_
+   from Proquest <http://search.proquest.com/docview/304915826>`_
 #.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification

--- a/sasmodels/models/core_shell_sphere.py
+++ b/sasmodels/models/core_shell_sphere.py
@@ -47,7 +47,7 @@ comparison of the output of our model and the output of the NIST software.
 References
 ----------
 
-.. [#] A Guinier and G Fournet, *Small-Angle Scattering of X-Rays*, John Wiley and Sons, New York, (1955)
+#.  A Guinier and G Fournet, *Small-Angle Scattering of X-Rays*, John Wiley and Sons, New York, (1955)
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/correlation_length.py
+++ b/sasmodels/models/correlation_length.py
@@ -29,7 +29,7 @@ where the q vector is defined as
 References
 ----------
 
-.. [#] B Hammouda, D L Ho and S R Kline, Insight into Clustering in Poly(ethylene oxide) Solutions, Macromolecules, 37 (2004) 6932-6937
+#.  B Hammouda, D L Ho and S R Kline, Insight into Clustering in Poly(ethylene oxide) Solutions, Macromolecules, 37 (2004) 6932-6937
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/cylinder.py
+++ b/sasmodels/models/cylinder.py
@@ -95,9 +95,9 @@ system, and then comparing to the 1D result.
 References
 ----------
 
-.. [#] J. Pedersen, *Adv. Colloid Interface Sci.*, 70 (1997) 171-210
-.. [#] G. Fournet, *Bull. Soc. Fr. Mineral. Cristallogr.*, 74 (1951) 39-113
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  J. Pedersen, *Adv. Colloid Interface Sci.*, 70 (1997) 171-210
+#.  G. Fournet, *Bull. Soc. Fr. Mineral. Cristallogr.*, 74 (1951) 39-113
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/dab.py
+++ b/sasmodels/models/dab.py
@@ -30,8 +30,8 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] P Debye, H R Anderson, H Brumberger, *Scattering by an Inhomogeneous Solid. II. The Correlation Function and its Application*, *J. Appl. Phys.*, 28(6) (1957) 679
-.. [#] P Debye, A M Bueche, *Scattering by an Inhomogeneous Solid*, *J. Appl. Phys.*, 20 (1949) 518
+#.  P Debye, H R Anderson, H Brumberger, *Scattering by an Inhomogeneous Solid. II. The Correlation Function and its Application*, *J. Appl. Phys.*, 28(6) (1957) 679
+#.  P Debye, A M Bueche, *Scattering by an Inhomogeneous Solid*, *J. Appl. Phys.*, 20 (1949) 518
 
 Source
 ------

--- a/sasmodels/models/ellipsoid.py
+++ b/sasmodels/models/ellipsoid.py
@@ -105,8 +105,8 @@ with polar radius equal to length and equatorial radius equal to radius.
 References
 ----------
 
-.. [#] L A Feigin and D I Svergun. *Structure Analysis by Small-Angle X-Ray and Neutron Scattering*, Plenum Press, New York, 1987
-.. [#] A. Isihara. *J. Chem. Phys.*, 18 (1950) 1446-1449
+#.  L A Feigin and D I Svergun. *Structure Analysis by Small-Angle X-Ray and Neutron Scattering*, Plenum Press, New York, 1987
+#.  A. Isihara. *J. Chem. Phys.*, 18 (1950) 1446-1449
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/elliptical_cylinder.py
+++ b/sasmodels/models/elliptical_cylinder.py
@@ -85,8 +85,8 @@ varying the number of angular bins.
 References
 ----------
 
-.. [#] L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and Neutron Scattering*, Plenum, New York, (1987) [see table 3.4]
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and Neutron Scattering*, Plenum, New York, (1987) [see table 3.4]
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/fcc_paracrystal.py
+++ b/sasmodels/models/fcc_paracrystal.py
@@ -27,8 +27,8 @@ the primary particle, $V_\text{lattice}$ is a volume correction for the crystal
 structure, $P(q)$ is the form factor of the sphere (normalized), and $Z(q)$
 is the paracrystalline structure factor for a face-centered cubic structure.
 
-Equation (1) of the 1990 reference\ [#CIT1990]_ is used to calculate $Z(q)$,
-using equations (23)-(25) from the 1987 paper\ [#CIT1987]_ for $Z1$, $Z2$, and
+Equation (1) of the 1990 reference\ [#Matsuoka1990]_ is used to calculate $Z(q)$,
+using equations (23)-(25) from the 1987 paper\ [#Matsuoka1987]_ for $Z1$, $Z2$, and
 $Z3$.
 
 The lattice correction (the occupied volume of the lattice) for a
@@ -93,9 +93,9 @@ Note that we are not responsible for any incorrectness of the
 References
 ----------
 
-.. [#CIT1987] Hideki Matsuoka et. al. *Physical Review B*, 36 (1987) 1754-1765
+.. [#Matsuoka1987] Hideki Matsuoka et. al. *Physical Review B*, 36 (1987) 1754-1765
    (Original Paper)
-.. [#CIT1990] Hideki Matsuoka et. al. *Physical Review B*, 41 (1990) 3854 -3856
+.. [#Matsuoka1990] Hideki Matsuoka et. al. *Physical Review B*, 41 (1990) 3854 -3856
    (Corrections to FCC and BCC lattice structure calculation)
 
 Authorship and Verification

--- a/sasmodels/models/flexible_cylinder.py
+++ b/sasmodels/models/flexible_cylinder.py
@@ -88,11 +88,11 @@ reader is strongly encouraged to read reference [1] before use.**
 References
 ----------
 
-.. [#] J S Pedersen and P Schurtenberger. *Scattering functions of semiflexible polymers with and without excluded volume effects.* Macromolecules, 29 (1996) 7602-7612
+#.  J S Pedersen and P Schurtenberger. *Scattering functions of semiflexible polymers with and without excluded volume effects.* Macromolecules, 29 (1996) 7602-7612
 
 Correction of the formula can be found in
 
-.. [#] W R Chen, P D Butler and L J Magid, *Incorporating Intermicellar Interactions in the Fitting of SANS Data from Cationic Wormlike Micelles.* Langmuir, 22(15) 2006 6539-6548
+#.  W R Chen, P D Butler and L J Magid, *Incorporating Intermicellar Interactions in the Fitting of SANS Data from Cationic Wormlike Micelles.* Langmuir, 22(15) 2006 6539-6548
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/flexible_cylinder_elliptical.py
+++ b/sasmodels/models/flexible_cylinder_elliptical.py
@@ -76,11 +76,11 @@ reader is strongly encouraged to read reference [1] before use.**
 References
 ----------
 
-.. [#] J S Pedersen and P Schurtenberger. *Scattering functions of semiflexible polymers with and without excluded volume effects.* Macromolecules, 29 (1996) 7602-7612
+#.  J S Pedersen and P Schurtenberger. *Scattering functions of semiflexible polymers with and without excluded volume effects.* Macromolecules, 29 (1996) 7602-7612
 
 Correction of the formula can be found in
 
-.. [#] W R Chen, P D Butler and L J Magid, *Incorporating Intermicellar Interactions in the Fitting of SANS Data from Cationic Wormlike Micelles.* Langmuir, 22(15) 2006 6539-6548
+#.  W R Chen, P D Butler and L J Magid, *Incorporating Intermicellar Interactions in the Fitting of SANS Data from Cationic Wormlike Micelles.* Langmuir, 22(15) 2006 6539-6548
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/fractal.py
+++ b/sasmodels/models/fractal.py
@@ -43,7 +43,7 @@ For 2D data: The 2D scattering intensity is calculated in the same way as
 References
 ----------
 
-.. [#] J Teixeira, *J. Appl. Cryst.*, 21 (1988) 781-785
+#.  J Teixeira, *J. Appl. Cryst.*, 21 (1988) 781-785
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/fractal_core_shell.py
+++ b/sasmodels/models/fractal_core_shell.py
@@ -3,7 +3,7 @@ Definition
 ----------
 Calculates the scattering from a fractal structure with a primary building
 block of core-shell spheres, as opposed to just homogeneous spheres in
-the fractal model. It is an extension of the well known Teixeira\ [#teixeira]_
+the fractal model. It is an extension of the well known Teixeira\ [#Teixeira1988]_
 fractal model replacing the $P(q)$ of a solid sphere with that of a core-shell
 sphere. This model could find use for aggregates of coated particles, or
 aggregates of vesicles for example.
@@ -13,7 +13,7 @@ aggregates of vesicles for example.
     I(q) = P(q)S(q) + \text{background}
 
 Where $P(q)$ is the core-shell form factor and $S(q)$ is the
-Teixeira\ [#teixeira]_ fractal structure factor both of which are given again
+Teixeira\ [#Teixeira1988]_ fractal structure factor both of which are given again
 below:
 
 .. math::
@@ -42,13 +42,13 @@ is calculated in the same way as 1D, where the $q$ vector is defined as
     q = \sqrt{q_x^2 + q_y^2}
 
 Our model is derived from the form factor calculations implemented in IGOR
-macros by the NIST Center for Neutron Research\ [#Kline]_
+macros by the NIST Center for Neutron Research\ [#Kline2006]_
 
 References
 ----------
 
-.. [#teixeira] J Teixeira, *J. Appl. Cryst.*, 21 (1988) 781-785
-.. [#Kline]  S R Kline, *J Appl. Cryst.*, 39 (2006) 895
+.. [#Teixeira1988] J Teixeira, *J. Appl. Cryst.*, 21 (1988) 781-785
+.. [#Kline2006]  S R Kline, *J Appl. Cryst.*, 39 (2006) 895
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/fuzzy_sphere.py
+++ b/sasmodels/models/fuzzy_sphere.py
@@ -50,7 +50,7 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] M Stieger, J. S Pedersen, P Lindner, W Richtering, *Langmuir*, 20 (2004) 7283-7292
+#.  M Stieger, J. S Pedersen, P Lindner, W Richtering, *Langmuir*, 20 (2004) 7283-7292
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/gauss_lorentz_gel.py
+++ b/sasmodels/models/gauss_lorentz_gel.py
@@ -31,7 +31,7 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] G Evmenenko, E Theunissen, K Mortensen, H Reynaers, *Polymer*, 42 (2001) 2907-2913
+#.  G Evmenenko, E Theunissen, K Mortensen, H Reynaers, *Polymer*, 42 (2001) 2907-2913
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/gel_fit.py
+++ b/sasmodels/models/gel_fit.py
@@ -36,9 +36,9 @@ In gels with significant hydrogen bonding $D$ has been reported to be
 References
 ----------
 
-.. [#] Mitsuhiro Shibayama, Toyoichi Tanaka, Charles C Han, *J. Chem. Phys.* 1992, 97 (9), 6829-6841
+#.  Mitsuhiro Shibayama, Toyoichi Tanaka, Charles C Han, *J. Chem. Phys.* 1992, 97 (9), 6829-6841
 
-.. [#] Simon Mallam, Ferenc Horkay, Anne-Marie Hecht, Adrian R Rennie, Erik Geissler, *Macromolecules* 1991, 24, 543-548
+#.  Simon Mallam, Ferenc Horkay, Anne-Marie Hecht, Adrian R Rennie, Erik Geissler, *Macromolecules* 1991, 24, 543-548
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/guinier.py
+++ b/sasmodels/models/guinier.py
@@ -45,7 +45,7 @@ negative value of $R_g^2$.
 References
 ----------
 
-.. [#] A Guinier and G Fournet, *Small-Angle Scattering of X-Rays*, John Wiley & Sons, New York (1955)
+#.  A Guinier and G Fournet, *Small-Angle Scattering of X-Rays*, John Wiley & Sons, New York (1955)
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/guinier_porod.py
+++ b/sasmodels/models/guinier_porod.py
@@ -59,8 +59,8 @@ where the q vector is defined as
 Reference
 ---------
 
-.. [#] B Hammouda, *A new Guinier-Porod model, J. Appl. Cryst.*, (2010), 43, 716-719
-.. [#] B Hammouda, *Analysis of the Beaucage model, J. Appl. Cryst.*, (2010), 43, 1474-1478
+#.  B Hammouda, *A new Guinier-Porod model*, *J. Appl. Cryst.*, (2010), 43, 716-719
+#.  B Hammouda, *Analysis of the Beaucage model*, *J. Appl. Cryst.*, (2010), 43, 1474-1478
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/hardsphere.py
+++ b/sasmodels/models/hardsphere.py
@@ -49,9 +49,9 @@ For a 2D plot, the wave transfer is defined as
 References
 ----------
 
-.. [#] M Kotlarchyk & S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
+#.  M Kotlarchyk & S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
 
-.. [#] J K Percus, J Yevick, *J. Phys. Rev.*, 110, (1958) 1
+#.  J K Percus, J Yevick, *J. Phys. Rev.*, 110, (1958) 1
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/hayter_msa.py
+++ b/sasmodels/models/hayter_msa.py
@@ -54,13 +54,13 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] J B Hayter and J Penfold, *Molecular Physics*, 42 (1981) 109-118
+#.  J B Hayter and J Penfold, *Molecular Physics*, 42 (1981) 109-118
 
-.. [#] J P Hansen and J B Hayter, *Molecular Physics*, 46 (1982) 651-656
+#.  J P Hansen and J B Hayter, *Molecular Physics*, 46 (1982) 651-656
 
-.. [#] M Kotlarchyk and S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
+#.  M Kotlarchyk and S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
 
-.. [#] C G Malmberg and A A Maryott, *J. Res. Nat. Bureau Standards*, 56 (1956) 2641
+#.  C G Malmberg and A A Maryott, *J. Res. Nat. Bureau Standards*, 56 (1956) 2641
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/hollow_cylinder.py
+++ b/sasmodels/models/hollow_cylinder.py
@@ -57,9 +57,9 @@ the axis of the cylinder using two angles $\theta$ and $\phi$
 References
 ----------
 
-.. [#] L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and
+#. L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and
    Neutron Scattering*, Plenum Press, New York, (1987)
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#. L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/hollow_rectangular_prism.py
+++ b/sasmodels/models/hollow_rectangular_prism.py
@@ -96,8 +96,10 @@ of the 1D model to the curves shown in (Nayuk, 2012).
 References
 ----------
 
+See also Onsager [#Onsager1949]_.
+
 .. [#Nayuk2012] R Nayuk and K Huber, *Z. Phys. Chem.*, 226 (2012) 837-854
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+.. [#Onsager1949] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/hollow_rectangular_prism_thin_walls.py
+++ b/sasmodels/models/hollow_rectangular_prism_thin_walls.py
@@ -70,8 +70,11 @@ of the 1D model to the curves shown in (Nayuk, 2012\ [#Nayuk2012]_).
 References
 ----------
 
+See also Onsager [#Onsager1949]_.
+
 .. [#Nayuk2012] R Nayuk and K Huber, *Z. Phys. Chem.*, 226 (2012) 837-854
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+
+.. [#Onsager1949] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/lamellar.py
+++ b/sasmodels/models/lamellar.py
@@ -39,8 +39,8 @@ the $q$ vector is defined as
 References
 ----------
 
-.. [#] F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
-.. [#] J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
+#.  F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
+#.  J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/lamellar_hg.py
+++ b/sasmodels/models/lamellar_hg.py
@@ -41,8 +41,8 @@ the $q$ vector is defined as
 References
 ----------
 
-.. [#] F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
-.. [#] J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
+#.  F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
+#.  J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/lamellar_hg_stack_caille.py
+++ b/sasmodels/models/lamellar_hg_stack_caille.py
@@ -68,8 +68,8 @@ the $q$ vector is defined as
 References
 ----------
 
-.. [#] F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
-.. [#] J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
+#.  F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
+#.  J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/lamellar_stack_caille.py
+++ b/sasmodels/models/lamellar_stack_caille.py
@@ -64,8 +64,8 @@ $q$ vector is defined as
 References
 ----------
 
-.. [#] F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
-.. [#] J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
+#.  F Nallet, R Laversanne, and D Roux, *J. Phys. II France*, 3, (1993) 487-502
+#.  J Berghausen, J Zipfel, P Lindner, W Richtering, *J. Phys. Chem. B*, 105, (2001) 11081-11088
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/lamellar_stack_paracrystal.py
+++ b/sasmodels/models/lamellar_stack_paracrystal.py
@@ -87,7 +87,7 @@ of the $q$ vector which is defined as
 Reference
 ---------
 
-.. [#] M Bergstrom, J S Pedersen, P Schurtenberger, S U Egelhaaf, *J. Phys. Chem. B*, 103 (1999) 9888-9897
+#.  M Bergstrom, J S Pedersen, P Schurtenberger, S U Egelhaaf, *J. Phys. Chem. B*, 103 (1999) 9888-9897
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/linear_pearls.py
+++ b/sasmodels/models/linear_pearls.py
@@ -28,7 +28,7 @@ regardless of the orientation of the q vector.
 References
 ----------
 
-.. [#] A V Dobrynin, M Rubinstein and S P Obukhov, *Macromol.*, 29 (1996) 2974-2979
+#.  A V Dobrynin, M Rubinstein and S P Obukhov, *Macromol.*, 29 (1996) 2974-2979
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/lorentz.py
+++ b/sasmodels/models/lorentz.py
@@ -19,7 +19,7 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] L.S. Qrnstein and F. Zernike, *Proc. Acad. Sci. Amsterdam* 17, 793 (1914), and *Z. Phys.* 19, 134 (1918), and 27, 761 {1926); referred to as QZ.
+#.  L.S. Qrnstein and F. Zernike, *Proc. Acad. Sci. Amsterdam* 17, 793 (1914), and *Z. Phys.* 19, 134 (1918), and 27, 761 {1926); referred to as QZ.
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/mass_fractal.py
+++ b/sasmodels/models/mass_fractal.py
@@ -48,7 +48,7 @@ length density of particles.
 References
 ----------
 
-.. [#] D Mildner and P Hall, *J. Phys. D: Appl. Phys.*, 19 (1986) 1535-1545 Equation(9)
+#.  D Mildner and P Hall, *J. Phys. D: Appl. Phys.*, 19 (1986) 1535-1545 Equation(9)
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/mass_surface_fractal.py
+++ b/sasmodels/models/mass_surface_fractal.py
@@ -50,8 +50,8 @@ and $\rho_{particle}$ is the scattering length density of particles.
 References
 ----------
 
-.. [#] P Schmidt, *J Appl. Cryst.*, 24 (1991) 414-435 Equation(19)
-.. [#] A J Hurd, D W Schaefer, J E Martin, *Phys. Rev. A*,
+#. P Schmidt, *J Appl. Cryst.*, 24 (1991) 414-435 Equation(19)
+#. A J Hurd, D W Schaefer, J E Martin, *Phys. Rev. A*,
    35 (1987) 2361-2364 Equation(2)
 
 Authorship and Verification

--- a/sasmodels/models/mono_gauss_coil.py
+++ b/sasmodels/models/mono_gauss_coil.py
@@ -44,9 +44,9 @@ but where the *q* vector is redefined as
 References
 ----------
 
-.. [#] P Debye, *J. Phys. Colloid. Chem.*, 51 (1947) 18.
-.. [#] R J Roe, *Methods of X-Ray and Neutron Scattering in Polymer Science*, Oxford University Press, New York (2000).
-.. [#] http://www.ncnr.nist.gov/staff/hammouda/distance_learning/chapter_28.pdf
+#.  P Debye, *J. Phys. Colloid. Chem.*, 51 (1947) 18.
+#.  R J Roe, *Methods of X-Ray and Neutron Scattering in Polymer Science*, Oxford University Press, New York (2000).
+#.  http://www.ncnr.nist.gov/staff/hammouda/distance_learning/chapter_28.pdf
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/multilayer_vesicle.py
+++ b/sasmodels/models/multilayer_vesicle.py
@@ -95,7 +95,7 @@ the :ref:`magnetism` documentation.
 References
 ----------
 
-.. [#] B Cabane, *Small Angle Scattering Methods*, in *Surfactant Solutions:
+#. B Cabane, *Small Angle Scattering Methods*, in *Surfactant Solutions:
    New Methods of Investigation*, Ch.2, Surfactant Science Series Vol. 22, Ed.
    R Zana and M Dekker, New York, (1987).
 

--- a/sasmodels/models/onion.py
+++ b/sasmodels/models/onion.py
@@ -182,7 +182,7 @@ when $P(q) S(q)$ is applied.
 References
 ----------
 
-.. [#] L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and Neutron Scattering*, Plenum Press, New York, 1987.
+#.  L A Feigin and D I Svergun, *Structure Analysis by Small-Angle X-Ray and Neutron Scattering*, Plenum Press, New York, 1987.
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/parallelepiped.py
+++ b/sasmodels/models/parallelepiped.py
@@ -50,7 +50,7 @@ and the $y$ axis) and the averaging $\left<\ldots\right>$ is applied over all
 orientations.
 
 Assuming $a = A/B < 1$, $b = B /B = 1$, and $c = C/B > 1$, the
-form factor is given by (Mittelbach and Porod, 1961 [#Mittelbach]_)
+form factor is given by (Mittelbach and Porod, 1961 [#Mittelbach1961]_)
 
 .. math::
 
@@ -176,10 +176,12 @@ angles.
 References
 ----------
 
-.. [#Mittelbach] P Mittelbach and G Porod, *Acta Physica Austriaca*,
+See also Nayuk [#Nayuk2012]_ and Onsager [#Onsager1949]_.
+
+.. [#Mittelbach1961] P Mittelbach and G Porod, *Acta Physica Austriaca*,
    14 (1961) 185-211
-.. [#] R Nayuk and K Huber, *Z. Phys. Chem.*, 226 (2012) 837-854
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+.. [#Nayuk2012] R Nayuk and K Huber, *Z. Phys. Chem.*, 226 (2012) 837-854
+.. [#Onsager1949] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/pearl_necklace.py
+++ b/sasmodels/models/pearl_necklace.py
@@ -49,10 +49,10 @@ orientation of the *q* vector.
 References
 ----------
 
-.. [#] R Schweins and K Huber, *Particle Scattering Factor of Pearl Necklace Chains*,
-       *Macromol. Symp.* 211 (2004) 25-42 2004
+#.  R Schweins and K Huber, *Particle Scattering Factor of Pearl Necklace Chains*,
+    *Macromol. Symp.* 211 (2004) 25-42 2004
 
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/poly_gauss_coil.py
+++ b/sasmodels/models/poly_gauss_coil.py
@@ -42,10 +42,10 @@ but where the $q$ vector is redefined as
 References
 ----------
 
-.. [#] O Glatter and O Kratky (editors), *Small Angle X-ray Scattering*, Academic Press, (1982) Page 404
-.. [#] J S Higgins, H C Benoit, *Polymers and Neutron Scattering*, Oxford Science Publications, (1996)
-.. [#] S M King, *Small Angle Neutron Scattering* in *Modern Techniques for Polymer Characterisation*, Wiley, (1999)
-.. [#] http://www.ncnr.nist.gov/staff/hammouda/distance_learning/chapter_28.pdf
+#.  O Glatter and O Kratky (editors), *Small Angle X-ray Scattering*, Academic Press, (1982) Page 404
+#.  J S Higgins, H C Benoit, *Polymers and Neutron Scattering*, Oxford Science Publications, (1996)
+#.  S M King, *Small Angle Neutron Scattering* in *Modern Techniques for Polymer Characterisation*, Wiley, (1999)
+#.  http://www.ncnr.nist.gov/staff/hammouda/distance_learning/chapter_28.pdf
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/polymer_excl_volume.py
+++ b/sasmodels/models/polymer_excl_volume.py
@@ -108,9 +108,9 @@ References
 ----------
 
 #.  H Benoit, *Comptes Rendus*, 245 (1957) 2244-2247
-#.  B Hammouda, *SANS from Homogeneous Polymer Mixtures - A Unified Overview, Advances in Polym. Sci.* 106 (1993) 87-133
-#.  M Hore et al, *Co-Nonsolvency of Poly(n-isopropylacrylamide) in Deuterated Water/Ethanol Mixtures* 46 (2013) 7894-7901
-#.  B Hammouda & M-H Kim, *The empirical core-chain model* 247 (2017) 434-440
+#.  B Hammouda, *SANS from Homogeneous Polymer Mixtures - A Unified Overview*, *Advances in Polym. Sci.* 106 (1993) 87-133
+#.  M Hore et al, *Co-Nonsolvency of Poly(N-isopropylacrylamide) in Deuterated Water/Ethanol Mixtures*, *Macromolecules* 46 (2013) 7894-7901
+#.  B Hammouda & M-H Kim, *The empirical core-chain model*, *Journal of Molecular Liquids* 247 (2017) 434-440
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/polymer_excl_volume.py
+++ b/sasmodels/models/polymer_excl_volume.py
@@ -107,10 +107,10 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] H Benoit, *Comptes Rendus*, 245 (1957) 2244-2247
-.. [#] B Hammouda, *SANS from Homogeneous Polymer Mixtures - A Unified Overview, Advances in Polym. Sci.* 106 (1993) 87-133
-.. [#] M Hore et al, *Co-Nonsolvency of Poly(n-isopropylacrylamide) in Deuterated Water/Ethanol Mixtures* 46 (2013) 7894-7901
-.. [#] B Hammouda & M-H Kim, *The empirical core-chain model* 247 (2017) 434-440
+#.  H Benoit, *Comptes Rendus*, 245 (1957) 2244-2247
+#.  B Hammouda, *SANS from Homogeneous Polymer Mixtures - A Unified Overview, Advances in Polym. Sci.* 106 (1993) 87-133
+#.  M Hore et al, *Co-Nonsolvency of Poly(n-isopropylacrylamide) in Deuterated Water/Ethanol Mixtures* 46 (2013) 7894-7901
+#.  B Hammouda & M-H Kim, *The empirical core-chain model* 247 (2017) 434-440
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/polymer_micelle.py
+++ b/sasmodels/models/polymer_micelle.py
@@ -67,7 +67,7 @@ model has not yet been independently validated.
 References
 ----------
 
-.. [#] J Pedersen, *J. Appl. Cryst.*, 33 (2000) 637-640
+#.  J Pedersen, *J. Appl. Cryst.*, 33 (2000) 637-640
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/porod.py
+++ b/sasmodels/models/porod.py
@@ -17,8 +17,8 @@ where the q vector is defined as
 References
 ----------
 
-.. [#] G Porod. *Kolloid Zeit*. 124 (1951) 83
-.. [#] L A Feigin, D I Svergun, G W Taylor. *Structure Analysis by Small-Angle X-ray and Neutron Scattering*. Springer. (1987)
+#.  G Porod. *Kolloid Zeit*. 124 (1951) 83
+#.  L A Feigin, D I Svergun, G W Taylor. *Structure Analysis by Small-Angle X-ray and Neutron Scattering*. Springer. (1987)
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/pringle.py
+++ b/sasmodels/models/pringle.py
@@ -39,8 +39,8 @@ Bessel function of the first kind.
 Reference
 ---------
 
-.. [#] Karen Edler, Universtiy of Bath, Private Communication. 2012. Derivation by Stefan Alexandru Rautu.
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  Karen Edler, Universtiy of Bath, Private Communication. 2012. Derivation by Stefan Alexandru Rautu.
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/raspberry.py
+++ b/sasmodels/models/raspberry.py
@@ -97,7 +97,7 @@ model parameters as:
 References
 ----------
 
-.. [#] K Larson-Smith, A Jackson, and D C Pozzo, *Small angle scattering model for Pickering emulsions and raspberry particles*, *Journal of Colloid and Interface Science*, 343(1) (2010) 36-41
+#.  K Larson-Smith, A Jackson, and D C Pozzo, *Small angle scattering model for Pickering emulsions and raspberry particles*, *Journal of Colloid and Interface Science*, 343(1) (2010) 36-41
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/rectangular_prism.py
+++ b/sasmodels/models/rectangular_prism.py
@@ -95,9 +95,9 @@ to the output of the existing :ref:`parallelepiped` model.
 References
 ----------
 
-.. [#] P Mittelbach and G Porod, *Acta Physica Austriaca*, 14 (1961) 185-211
-.. [#] R Nayuk and K Huber, *Z. Phys. Chem.*, 226 (2012) 837-854
-.. [#] L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
+#.  P Mittelbach and G Porod, *Acta Physica Austriaca*, 14 (1961) 185-211
+#.  R Nayuk and K Huber, *Z. Phys. Chem.*, 226 (2012) 837-854
+#.  L. Onsager, *Ann. New York Acad. Sci.*, 51 (1949) 627-659
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/rpa.py
+++ b/sasmodels/models/rpa.py
@@ -62,9 +62,9 @@ USAGE NOTES:
 References
 ----------
 
-.. [#] A Z Akcasu, R Klein and B Hammouda, *Macromolecules*, 26 (1993) 4136
-.. [#] B. Hammouda, *Advances in Polymer Science* 106 (1993) 87
-.. [#] B. Hammouda, *SANS Toolbox* https://www.ncnr.nist.gov/staff/hammouda/the_sans_toolbox.pdf.
+#.  A Z Akcasu, R Klein and B Hammouda, *Macromolecules*, 26 (1993) 4136
+#.  B. Hammouda, *Advances in Polymer Science* 106 (1993) 87
+#.  B. Hammouda, *SANS Toolbox* https://www.ncnr.nist.gov/staff/hammouda/the_sans_toolbox.pdf.
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/sc_paracrystal.py
+++ b/sasmodels/models/sc_paracrystal.py
@@ -24,8 +24,8 @@ the primary particle, $V_\text{lattice}$ is a volume correction for the crystal
 structure, $P(q)$ is the form factor of the sphere (normalized), and
 $Z(q)$ is the paracrystalline structure factor for a simple cubic structure.
 
-Equation (16) of the 1987 reference\ [#CIT1987]_ is used to calculate $Z(q)$,
-using equations (13)-(15) from the 1987 paper\ [#CIT1990]_ for $Z1$, $Z2$, and
+Equation (16) of the 1987 reference\ [#Matsuoka1987]_ is used to calculate $Z(q)$,
+using equations (13)-(15) from the 1987 paper\ [#Matsuoka1990]_ for $Z1$, $Z2$, and
 $Z3$.
 
 The lattice correction (the occupied volume of the lattice) for a simple cubic
@@ -97,8 +97,8 @@ Note that we are not responsible for any incorrectness of the
 Reference
 ---------
 
-.. [#CIT1987] Hideki Matsuoka et. al. *Physical Review B*, 36 (1987) 1754-1765 (Original Paper)
-.. [#CIT1990] Hideki Matsuoka et. al. *Physical Review B*, 41 (1990) 3854 -3856 (Corrections to FCC and BCC lattice structure calculation)
+.. [#Matsuoka1987] Hideki Matsuoka et. al. *Physical Review B*, 36 (1987) 1754-1765 (Original Paper)
+.. [#Matsuoka1990] Hideki Matsuoka et. al. *Physical Review B*, 41 (1990) 3854 -3856 (Corrections to FCC and BCC lattice structure calculation)
 
 Authorship and Verification
 ---------------------------

--- a/sasmodels/models/sphere.py
+++ b/sasmodels/models/sphere.py
@@ -36,7 +36,7 @@ to the output of the software provided by the NIST (Kline, 2006).
 References
 ----------
 
-.. [#] A Guinier and G. Fournet, *Small-Angle Scattering of X-Rays*,
+#. A Guinier and G. Fournet, *Small-Angle Scattering of X-Rays*,
    John Wiley and Sons, New York, (1955)
 
 Authorship and Verification

--- a/sasmodels/models/spherical_sld.py
+++ b/sasmodels/models/spherical_sld.py
@@ -183,7 +183,7 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] L A Feigin and D I Svergun, Structure Analysis by Small-Angle X-Ray
+#. L A Feigin and D I Svergun, Structure Analysis by Small-Angle X-Ray
    and Neutron Scattering, Plenum Press, New York, (1987)
 
 Authorship and Verification

--- a/sasmodels/models/spinodal.py
+++ b/sasmodels/models/spinodal.py
@@ -39,9 +39,9 @@ scattering, or to simply omit the low-angle scattering from the fit.
 References
 ----------
 
-.. [#] H. Furukawa. Dynamics-scaling theory for phase-separating unmixing mixtures: Growth rates of droplets and scaling properties of autocorrelation functions. Physica A 123, 497 (1984).
-.. [#] H. Meier & G. Strobl. Small-Angle X-ray Scattering Study of Spinodal Decomposition in Polystyrene/Poly(styrene-co-bromostyrene) Blends. Macromolecules 20, 649-654 (1987).
-.. [#] T. Hashimoto, M. Takenaka & H. Jinnai. Scattering Studies of Self-Assembling Processes of Polymer Blends in Spinodal Decomposition. J. Appl. Cryst. 24, 457-466 (1991).
+#.  H. Furukawa. Dynamics-scaling theory for phase-separating unmixing mixtures: Growth rates of droplets and scaling properties of autocorrelation functions. Physica A 123, 497 (1984).
+#.  H. Meier & G. Strobl. Small-Angle X-ray Scattering Study of Spinodal Decomposition in Polystyrene/Poly(styrene-co-bromostyrene) Blends. Macromolecules 20, 649-654 (1987).
+#.  T. Hashimoto, M. Takenaka & H. Jinnai. Scattering Studies of Self-Assembling Processes of Polymer Blends in Spinodal Decomposition. J. Appl. Cryst. 24, 457-466 (1991).
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/spinodal.py
+++ b/sasmodels/models/spinodal.py
@@ -39,9 +39,9 @@ scattering, or to simply omit the low-angle scattering from the fit.
 References
 ----------
 
-#.  H. Furukawa. Dynamics-scaling theory for phase-separating unmixing mixtures: Growth rates of droplets and scaling properties of autocorrelation functions. Physica A 123, 497 (1984).
-#.  H. Meier & G. Strobl. Small-Angle X-ray Scattering Study of Spinodal Decomposition in Polystyrene/Poly(styrene-co-bromostyrene) Blends. Macromolecules 20, 649-654 (1987).
-#.  T. Hashimoto, M. Takenaka & H. Jinnai. Scattering Studies of Self-Assembling Processes of Polymer Blends in Spinodal Decomposition. J. Appl. Cryst. 24, 457-466 (1991).
+#.  H. Furukawa. Dynamics-scaling theory for phase-separating unmixing mixtures: Growth rates of droplets and scaling properties of autocorrelation functions. *Physica A* 123, 497 (1984).
+#.  H. Meier & G. Strobl. Small-Angle X-ray Scattering Study of Spinodal Decomposition in Polystyrene/Poly(styrene-co-bromostyrene) Blends. *Macromolecules* 20, 649-654 (1987).
+#.  T. Hashimoto, M. Takenaka & H. Jinnai. Scattering Studies of Self-Assembling Processes of Polymer Blends in Spinodal Decomposition. *J. Appl. Cryst.* 24, 457-466 (1991).
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/squarewell.py
+++ b/sasmodels/models/squarewell.py
@@ -49,9 +49,9 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] R V Sharma, K C Sharma, *Physica*, 89A (1977) 213
+#.  R V Sharma, K C Sharma, *Physica*, 89A (1977) 213
 
-.. [#] M Kotlarchyk and S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
+#.  M Kotlarchyk and S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/stacked_disks.py
+++ b/sasmodels/models/stacked_disks.py
@@ -5,7 +5,7 @@ Definition
 This model provides the form factor, $P(q)$, for stacked discs (tactoids)
 with a core/layer structure which is constructed itself as $P(q) S(Q)$
 multiplying a $P(q)$ for individual core/layer disks by a structure factor
-$S(q)$ proposed by Kratky and Porod in 1949\ [#CIT1949]_ assuming the next
+$S(q)$ proposed by Kratky and Porod in 1949\ [#Kratky1949]_ assuming the next
 neighbor distance (d-spacing) in the stack of parallel discs obeys a Gaussian
 distribution. As such the normalization of this "composite" form factor is
 relative to the individual disk volume, not the volume of the stack of disks.
@@ -89,16 +89,18 @@ see :ref:`orientation`.
 
 
 Our model is derived from the form factor calculations implemented in a
-c-library provided by the NIST Center for Neutron Research\ [#CIT_Kline]_
+C-library provided by the NIST Center for Neutron Research\ [#Kline2006]_
 
 References
 ----------
 
-.. [#CIT1949] O Kratky and G Porod, *J. Colloid Science*, 4, (1949) 35
-.. [#CIT_Kline] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
-.. [#] J S Higgins and H C Benoit, *Polymers and Neutron Scattering*,
+See also Higgins and Benoit [#Higgins1994]_ and Guinier and Fournet [#Guinier1955]_.
+
+.. [#Kratky1949] O Kratky and G Porod, *J. Colloid Science*, 4, (1949) 35
+.. [#Kline2006] S R Kline, *J Appl. Cryst.*, 39 (2006) 895
+.. [#Higgins1994] J S Higgins and H C Benoit, *Polymers and Neutron Scattering*,
    Clarendon, Oxford, 1994
-.. [#] A Guinier and G Fournet, *Small-Angle Scattering of X-Rays*,
+.. [#Guinier1955] A Guinier and G Fournet, *Small-Angle Scattering of X-Rays*,
    John Wiley and Sons, New York, 1955
 
 Authorship and Verification

--- a/sasmodels/models/star_polymer.py
+++ b/sasmodels/models/star_polymer.py
@@ -6,7 +6,7 @@ Calcuates the scattering from a simple star polymer with f equal Gaussian coil
 arms. A star being defined as a branched polymer with all the branches
 emanating from a common central (in the case of this model) point.  It is
 derived as a special case of on the Benoit model for general branched
-polymers\ [#CITBenoit]_ as also used by Richter *et al.*\ [#CITRichter]_
+polymers\ [#Benoit1953]_ as also used by Richter *et al.*\ [#Richter1989]_
 
 For a star with $f$ arms the scattering intensity $I(q)$ is calculated as
 
@@ -45,8 +45,8 @@ equation is recovered.
 References
 ----------
 
-.. [#CITBenoit] H Benoit *J. Polymer Science*, 11, 507-510 (1953)
-.. [#CITRichter] D Richter, B. Farago, J. S. Huang, L. J. Fetters,
+.. [#Benoit1953] H Benoit *J. Polymer Science*, 11, 507-510 (1953)
+.. [#Richter1989] D Richter, B. Farago, J. S. Huang, L. J. Fetters,
    B Ewen *Macromolecules*, 22, 468-472 (1989)
 
 Authorship and Verification

--- a/sasmodels/models/stickyhardsphere.py
+++ b/sasmodels/models/stickyhardsphere.py
@@ -71,11 +71,11 @@ as 1D, where the $q$ vector is defined as
 References
 ----------
 
-.. [#] S V G Menon, C Manohar, and K S Rao, *J. Chem. Phys.*, 95(12) (1991) 9186-9190
+#.  S V G Menon, C Manohar, and K S Rao, *J. Chem. Phys.*, 95(12) (1991) 9186-9190
 
-.. [#] R J Baxter, *J. Chem. Phys.*, 49 (1968), 2770-2774
+#.  R J Baxter, *J. Chem. Phys.*, 49 (1968), 2770-2774
 
-.. [#] M Kotlarchyk and S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
+#.  M Kotlarchyk and S-H Chen, *J. Chem. Phys.*, 79 (1983) 2461-2469
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/surface_fractal.py
+++ b/sasmodels/models/surface_fractal.py
@@ -35,7 +35,7 @@ length density of particles.
 References
 ----------
 
-.. [#] D Mildner and P Hall, *J. Phys. D: Appl. Phys.*, 19 (1986) 1535-1545
+#.  D Mildner and P Hall, *J. Phys. D: Appl. Phys.*, 19 (1986) 1535-1545
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/teubner_strey.py
+++ b/sasmodels/models/teubner_strey.py
@@ -60,9 +60,9 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] M Teubner, R Strey, *J. Chem. Phys.*, 87 (1987) 3195
-.. [#] K V Schubert, R Strey, S R Kline and E W Kaler, *J. Chem. Phys.*, 101 (1994) 5343
-.. [#] H Endo, M Mihailescu, M. Monkenbusch, J Allgaier, G Gompper, D Richter, B Jakobs, T Sottmann, R Strey, and I Grillo, *J. Chem. Phys.*, 115 (2001), 580
+#.  M Teubner, R Strey, *J. Chem. Phys.*, 87 (1987) 3195
+#.  K V Schubert, R Strey, S R Kline and E W Kaler, *J. Chem. Phys.*, 101 (1994) 5343
+#.  H Endo, M Mihailescu, M. Monkenbusch, J Allgaier, G Gompper, D Richter, B Jakobs, T Sottmann, R Strey, and I Grillo, *J. Chem. Phys.*, 115 (2001), 580
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/triaxial_ellipsoid.py
+++ b/sasmodels/models/triaxial_ellipsoid.py
@@ -113,7 +113,7 @@ over all possible angles.
 References
 ----------
 
-.. [#] Finnigan, J.A., Jacobs, D.J., 1971. *Light scattering by ellipsoidal particles in solution*, J. Phys. D: Appl. Phys. 4, 72-77. doi:10.1088/0022-3727/4/1/310
+#.  Finnigan, J.A., Jacobs, D.J., 1971. *Light scattering by ellipsoidal particles in solution*, J. Phys. D: Appl. Phys. 4, 72-77. doi:10.1088/0022-3727/4/1/310
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/unified_power_Rg.py
+++ b/sasmodels/models/unified_power_Rg.py
@@ -62,9 +62,9 @@ where the $q$ vector is defined as
 References
 ----------
 
-.. [#] G Beaucage, *J. Appl. Cryst.*, 28 (1995) 717-728
-.. [#] G Beaucage, *J. Appl. Cryst.*, 29 (1996) 134-146
-.. [#] B Hammouda, *Analysis of the Beaucage model, J. Appl. Cryst.*, (2010), 43, 1474-1478
+#.  G Beaucage, *J. Appl. Cryst.*, 28 (1995) 717-728
+#.  G Beaucage, *J. Appl. Cryst.*, 29 (1996) 134-146
+#.  B Hammouda, *Analysis of the Beaucage model, J. Appl. Cryst.*, (2010), 43, 1474-1478
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/models/vesicle.py
+++ b/sasmodels/models/vesicle.py
@@ -6,7 +6,7 @@ This model provides the form factor, *P(q)*, for an unilamellar vesicle and is
 effectively identical to the hollow sphere reparameterized to be
 more intuitive for a vesicle and normalizing the form factor by the volume of
 the shell. The 1D scattering intensity is calculated in the following way
-(Guinier,1955\ [#Guinier1955]_)
+[#Guinier1955]_:
 
 .. math::
 
@@ -56,8 +56,8 @@ radius for *S(Q)* when *P(Q)* \* *S(Q)* is applied.
 References
 ----------
 
-.. [#Guinier1955] A Guinier and G. Fournet, *Small-Angle Scattering of X-Rays*, John Wiley and
-   Sons, New York, (1955)
+.. [#Guinier1955] A Guinier and G. Fournet, *Small-Angle Scattering of X-Rays*,
+   John Wiley and Sons, New York, (1955)
 
 Authorship and Verification
 ----------------------------

--- a/sasmodels/special.py
+++ b/sasmodels/special.py
@@ -108,7 +108,7 @@ file in the order given, otherwise these functions will not be available.
         sorted from highest to lowest.
 
     sas_gamma(x):
-        Gamma function $\text{sas_gamma}(x) = \Gamma(x)$.
+        Gamma function sas_gamma\ $(x) = \Gamma(x)$.
 
         The standard math function, tgamma(x) is unstable for $x < 1$
         on some platforms.
@@ -127,35 +127,35 @@ file in the order given, otherwise these functions will not be available.
 
     sas_erf(x), sas_erfc(x):
         Error function
-        $\text{sas_erf}(x) = \frac{2}{\sqrt\pi}\int_0^x e^{-t^2}\,dt$
+        sas_erf\ $(x) = \frac{2}{\sqrt\pi}\int_0^x e^{-t^2}\,dt$
         and complementary error function
-        $\text{sas_erfc}(x) = \frac{2}{\sqrt\pi}\int_x^{\infty} e^{-t^2}\,dt$.
+        sas_erfc\ $(x) = \frac{2}{\sqrt\pi}\int_x^{\infty} e^{-t^2}\,dt$.
 
         The standard math functions erf(x) and erfc(x) are slower and broken
         on some platforms.
 
     sas_J0(x):
-        Bessel function of the first kind $\text{sas_J0}(x)=J_0(x)$ where
+        Bessel function of the first kind sas_J0\ $(x)=J_0(x)$ where
         $J_0(x) = \frac{1}{\pi}\int_0^\pi \cos(x\sin(\tau))\,d\tau$.
 
         The standard math function j0(x) is not available on all platforms.
 
     sas_J1(x):
-        Bessel function of the first kind  $\text{sas_J1}(x)=J_1(x)$ where
+        Bessel function of the first kind  sas_J1\ $(x)=J_1(x)$ where
         $J_1(x) = \frac{1}{\pi}\int_0^\pi \cos(\tau - x\sin(\tau))\,d\tau$.
 
         The standard math function j1(x) is not available on all platforms.
 
     sas_JN(n, x):
         Bessel function of the first kind and integer order $n$:
-        $\text{sas_JN}(n, x)=J_n(x)$ where
+        sas_JN\ $(n, x)=J_n(x)$ where
         $J_n(x) = \frac{1}{\pi}\int_0^\pi \cos(n\tau - x\sin(\tau))\,d\tau$.
         If $n$ = 0 or 1, it uses sas_J0(x) or sas_J1(x), respectively.
 
         The standard math function jn(n, x) is not available on all platforms.
 
     sas_Si(x):
-        Sine integral $\text{Si}(x) = \int_0^x \tfrac{\sin t}{t}\,dt$.
+        Sine integral sas_Si\ $(x) = \int_0^x \tfrac{\sin t}{t}\,dt$.
 
         This function uses Taylor series for small and large arguments:
 
@@ -179,7 +179,7 @@ file in the order given, otherwise these functions will not be available.
 
     sas_3j1x_x(x):
         Spherical Bessel form
-        $\text{sph_j1c}(x) = 3 j_1(x)/x = 3 (\sin(x) - x \cos(x))/x^3$,
+        sas_3j1x_x\ $(x) = 3 j_1(x)/x = 3 (\sin(x) - x \cos(x))/x^3$,
         with a limiting value of 1 at $x=0$, where $j_1(x)$ is the spherical
         Bessel function of the first kind and first order.
 
@@ -187,7 +187,7 @@ file in the order given, otherwise these functions will not be available.
 
 
     sas_2J1x_x(x):
-        Bessel form $\text{sas_J1c}(x) = 2 J_1(x)/x$, with a limiting value
+        Bessel form sas_2J1x_x\ $(x) = 2 J_1(x)/x$, with a limiting value
         of 1 at $x=0$, where $J_1(x)$ is the Bessel function of first kind
         and first order.
 


### PR DESCRIPTION
In this PR the footnotes within the `sasmodels/models/*.py` documentation are all changed to either be 
* named autonumbered footnotes and referred to from the text, or
* numbered lists with no in-text citations

These changes make substantial progress towards https://github.com/SasView/sasview/pull/1401.

The documentation of the special functions (`special.py`) generated LaTeX errors from the placement of underscores and so is also fixed here.

There were additionally a handful of mistakes in spelling or in reference details that I noticed at the same time and fixed; this was not a thorough process, however.

Closes: #378 