### PR TITLE
Quote PYTHON for spaces in interperter path

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 PYTHON       ?= python
 SPHINXOPTS    =
-SPHINXBUILD   = $(PYTHON) -m  sphinx
+SPHINXBUILD   = "$(PYTHON)" -m sphinx
 PAPER        ?= letter
 BUILDDIR      = _build
 ifdef ComSpec
@@ -52,16 +52,16 @@ else
 endif
 
 model/%.rst: ../sasmodels/models/%.py model/img genmodel.py
-	$(PYTHON) genmodel.py $< $@
+	"$(PYTHON)" genmodel.py $< $@
 
 ref/models/index.rst: gentoc.py $(MODELS_PY)
-	$(PYTHON) gentoc.py $(MODELS_PY)
+	"$(PYTHON)" gentoc.py $(MODELS_PY)
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest build
 
 api: genapi.py
 	-$(RMDIR) api
-	$(PYTHON) genapi.py
+	"$(PYTHON)" genapi.py
 
 model:
 	$(MKDIR) model


### PR DESCRIPTION
As @pkienzle notes in https://github.com/SasView/sasview/pull/1429, this is needed to support setting PYTHON with paths that have spaces.