### PR TITLE
Doc gen speedup, improved random model generation and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,14 @@
 *.def
 *.so
 *.obj
+__pycache__
 /doc/_build/
 /doc/api/
 /doc/model/
 /doc/guide/models
-.mplconfig
 /pylint_violations.txt
 /coverage.xml
+/.mplconfig
 /.coverage
 /.project
 /.pydevproject

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ ALLSPHINXOPTS   = -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 IMG_SOURCE = $(wildcard ../sasmodels/models/img/*)
 IMG_DEST = $(patsubst ../sasmodels/models/img/%,model/img/%,$(IMG_SOURCE))
 MODELS_PY = $(wildcard ../sasmodels/models/[a-z]*.py)
-MODELS_RST = $(patsubst ../sasmodels/models/%.py,model/%.rst,$(MODELS_PY))
+#MODELS_RST = $(patsubst ../sasmodels/models/%.py,model/%.rst,$(MODELS_PY))
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -51,10 +51,8 @@ else
 	$(COPY) $< $@
 endif
 
-model/%.rst: ../sasmodels/models/%.py model/img genmodel.py
-	"$(PYTHON)" genmodel.py $< $@
-
-ref/models/index.rst: gentoc.py $(MODELS_PY)
+ref/models/index.rst: gentoc.py genmodel.py $(MODELS_PY)
+	"$(PYTHON)" genmodel.py $(MODELS_PY)
 	"$(PYTHON)" gentoc.py $(MODELS_PY)
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest build
@@ -73,7 +71,7 @@ else
 	$(MKDIR) model/img
 endif
 
-build: model $(MODELS_RST) $(IMG_DEST) api ref/models/index.rst
+build: model $(IMG_DEST) api ref/models/index.rst
 ifdef ComSpec
 	rem cd ..\..
 	rem python setup.py build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -84,7 +84,7 @@ upload:
 	scp _build/latex/SASModels.pdf reflectometry.org:web/danse/download
 
 clean:
-	-$(RMDIR) _build model api ref$(PATHSEP)models
+	-$(RMDIR) _build model api guide$(PATHSEP)models
 
 html: build
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html

--- a/doc/genmodel.py
+++ b/doc/genmodel.py
@@ -1,3 +1,36 @@
+"""
+Generate ReST docs with figures for each model.
+
+usage: python genmodels.py path/to/model1.py ...
+
+Output is placed in the directory model, with *model1.py* producing
+*model/model1.rst* and *model/img/model1.png*.
+
+Set the environment variable SASMODELS_BUILD_CACHE to the path for the
+build cache. That way the figure will only be regenerated if the kernel
+code has changed.  This is useful on a build server where the environment
+is created from scratch each time.  Be sure to clear the cache from time
+to time so it doesn't get too large.  Also, the cache will need to be
+cleared if the image generation is updated, either because matplotib
+is upgraded or because this file changes.  To accomodate both these
+conditions set the path as the following in your build script::
+
+    SASMODELS_BUILD_CACHE=/tmp/sasbuild_$(shasum genmodel.py)
+
+Putting the cache in /tmp allows temp-reaper to clean it up automatically.
+Putting the sha1 hash of this file in the cache directory name means that
+a new cache will be created whenever the text of this file has changed,
+even if it is downloaded from a different branch of the repo.
+
+The release build should not use any caching.
+
+This program uses multiprocessing to build the jobs in parallel.  Use
+the following::
+
+    SASMODELS_BUILD_CPUS=0  # one per processor
+    SASMODELS_BUILD_CPUS=1  # don't use multiprocessing
+    SASMODELS_BUILD_CPUS=n  # use n processes
+"""
 from __future__ import print_function
 
 import sys
@@ -19,12 +52,8 @@ else:
                 raise
 
 import numpy as np
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 
 sys.path.insert(0, realpath(joinpath(dirname(__file__), '..')))
-import sasmodels
 from sasmodels import generate, core
 from sasmodels.direct_model import DirectModel, call_profile
 from sasmodels.data import empty_data1D, empty_data2D
@@ -80,6 +109,7 @@ def plot_profile_inset(model_info, ax):
     """
     Plot 1D radial profile as inset plot.
     """
+    import matplotlib.pyplot as plt
     p = ax.get_position()
     width, height = 0.4*(p.x1-p.x0), 0.4*(p.y1-p.y0)
     left, bottom = p.x1-width, p.y1-height
@@ -103,6 +133,8 @@ def make_figure(model_info, opts):
     """
     Generate the figure file to include in the docs.
     """
+    import matplotlib.pyplot as plt
+
     model = core.build_model(model_info)
 
     fig_height = 3.0 # in
@@ -146,18 +178,19 @@ def make_figure(model_info, opts):
     makedirs(joinpath('model', 'img'), exist_ok=True)
     path = joinpath('model', 'img', figfile(model_info))
     plt.savefig(path, bbox_inches='tight')
+    plt.close(fig)
     #print("figure saved in",path)
+
+def newer(src, dst):
+    return not exists(dst) or os.path.getmtime(src) > os.path.getmtime(dst)
 
 def copy_if_newer(src, dst):
     # type: (str) -> str
     """
     Copy from *src* to *dst* if *src* is newer or *dst* doesn't exist.
     """
-    if not exists(dst):
-        path = dirname(dst)
-        makedirs(path, exist_ok=True)
-        shutil.copy2(src, dst)
-    elif os.path.getmtime(src) > os.path.getmtime(dst):
+    if newer(src, dst):
+        makedirs(dirname(dst), exist_ok=True)
         shutil.copy2(src, dst)
 
 def link_sources(model_info):
@@ -214,7 +247,6 @@ def gen_docs(model_info, outfile):
     """
     Generate the doc string with the figure inserted before the references.
     """
-
     # Load the doc string from the module definition file and store it in rst
     docstr = generate.make_doc(model_info)
 
@@ -249,17 +281,84 @@ def gen_docs(model_info, outfile):
     with open(outfile, 'w') as fid:
         fid.write(docstr)
 
-def process_model(infile, outfile):
-    # type: (str, str) -> None
+def make_figure_cached(model_info, opts):
+    """
+    Cache sasmodels figures between independent builds.
+
+    To enable caching, set *SASMODELS_BUILD_CACHE* in the environment.
+    A (mostly) unique key will be created based on model source and opts.  If
+    the png file matching that key exists in the cache it will be copied into
+    the documentation tree, otherwise a new png file will be created and copied
+    into the cache.
+
+    Be sure to clear the cache from time to time.  Even though the model
+    source
+    """
+    import hashlib
+
+    # check if we are caching
+    cache_dir = os.environ.get('SASMODELS_BUILD_CACHE', None)
+    if cache_dir is None:
+        make_figure(model_info, opts)
+        return
+
+    # TODO: changing default parameters won't trigger a rebuild.
+    # build cache identifier
+    if callable(model_info.Iq):
+        with open(model_info.filename) as fid:
+            source = fid.read()
+    else:
+        source = generate.make_source(model_info)["dll"]
+    pars = str(sorted(model_info.parameters.defaults.items()))
+    code = source + pars + str(sorted(opts.items()))
+    hash_id = hashlib.sha1(code.encode('utf-8')).hexdigest()
+
+    # copy from cache or generate and copy to cache
+    png_name = figfile(model_info)
+    target_fig = joinpath('model', 'img', png_name)
+    cache_fig = joinpath(cache_dir, f"{png_name}.{hash_id}.png")
+    if exists(cache_fig):
+        copy_file(cache_fig, target_fig)
+    else:
+        #print(f"==>regenerating png {model_info.id}")
+        make_figure(model_info, opts)
+        copy_file(target_fig, cache_fig)
+
+def copy_file(src, dst):
+    # type: (str) -> str
+    """
+    Copy from *src* to *dst*, making the destination directory if needed.
+    """
+    if not exists(dst):
+        path = dirname(dst)
+        makedirs(path, exist_ok=True)
+        shutil.copy2(src, dst)
+    elif os.path.getmtime(src) > os.path.getmtime(dst):
+        shutil.copy2(src, dst)
+
+def process_model(py_file, force=False):
+    # type: (str) -> None
     """
     Generate doc file and image file for the given model definition file.
+
+    Does nothing if the corresponding rst file is newer than *py_file*.
+    Also checks the timestamp on the *genmodel.py* program (*__file__*),
+    since we want to rerun the generator on all files if we change this
+    code.
+
+    If *force* then generate the rst file regardless of time stamps.
     """
+    rst_file = joinpath('model', basename(py_file).replace('.py', '.rst'))
+    if not (force or newer(py_file, rst_file) or newer(__file__, rst_file)):
+        #print("skipping", rst_file)
+        return
+
     # Load the model file
-    model_name = basename(infile)[:-3]
+    model_name = basename(py_file)[:-3]
     model_info = core.load_model_info(model_name)
 
     # Plotting ranges and options
-    opts = {
+    PLOT_OPTS = {
         'xscale'    : 'log',
         'yscale'    : 'log' if not model_info.structure_factor else 'linear',
         'zscale'    : 'log' if not model_info.structure_factor else 'linear',
@@ -275,12 +374,31 @@ def process_model(infile, outfile):
     }
 
     # Generate the RST file and the figure.  Order doesn't matter.
-    gen_docs(model_info, outfile)
-    make_figure(model_info, opts)
+    print("generating", rst_file)
+    gen_docs(model_info, rst_file)
+    make_figure_cached(model_info, PLOT_OPTS)
 
-def main():
-    infile, outfile = sys.argv[1], sys.argv[2]
-    process_model(infile, outfile)
+def main(cpus=None):
+    """
+    Process files listed on the command line via :func:`process_model`.
+
+    *cpus* indicates the number of parallel processes. Use *cpus=0* for one
+    process per cpu or *cpus=1* for no multiprocessing. If *cpus=None* then
+    use the value in SASMODELS_BUILD_CPUS from the environment, or 0 if no
+    environment variable is found.
+    """
+    import matplotlib
+    matplotlib.use('Agg')
+
+    if cpus is None:
+        cpus = int(os.environ.get("SASMODELS_BUILD_CPUS", "0"))
+    if cpus != 1:
+        import multiprocessing
+        p = multiprocessing.Pool(cpus if cpus > 0 else None)
+        p.map(process_model, sys.argv[1:])
+    else:
+        for py_file in sys.argv[1:]:
+            process_model(py_file)
 
 if __name__ == "__main__":
     main()

--- a/doc/genmodel.py
+++ b/doc/genmodel.py
@@ -15,7 +15,7 @@ cleared if the image generation is updated, either because matplotib
 is upgraded or because this file changes.  To accomodate both these
 conditions set the path as the following in your build script::
 
-    SASMODELS_BUILD_CACHE=/tmp/sasbuild_$(shasum genmodel.py)
+    SASMODELS_BUILD_CACHE=/tmp/sasbuild_$(shasum genmodel.py | cut -f 1 -d" ")
 
 Putting the cache in /tmp allows temp-reaper to clean it up automatically.
 Putting the sha1 hash of this file in the cache directory name means that
@@ -59,6 +59,7 @@ else:
 
 import numpy as np
 
+# TODO: Remove this line when genmodel is moved to the sasmodels directory.
 sys.path.insert(0, realpath(joinpath(dirname(__file__), '..')))
 from sasmodels import generate, core
 from sasmodels.direct_model import DirectModel, call_profile
@@ -66,7 +67,7 @@ from sasmodels.data import empty_data1D, empty_data2D
 
 try:
     from typing import Dict, Any
-    from matplotlib.axes import Axes
+    #from matplotlib.axes import Axes
     from sasmodels.kernel import KernelModel
     from sasmodels.modelinfo import ModelInfo
 except ImportError:

--- a/doc/genmodel.py
+++ b/doc/genmodel.py
@@ -30,6 +30,12 @@ the following::
     SASMODELS_BUILD_CPUS=0  # one per processor
     SASMODELS_BUILD_CPUS=1  # don't use multiprocessing
     SASMODELS_BUILD_CPUS=n  # use n processes
+
+Note that sasmodels with OpenCL is very good at using all the processors
+when generating the model plot, so you should only use a small amount
+of parallelism (maybe 2-4 processes), allowing matplotlib to run in
+parallel.  More parallelism won't help, and may overwhelm the GPU if you
+have one.
 """
 from __future__ import print_function
 

--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -64,4 +64,7 @@ The model figure generation is controlled by a environment variables::
 
     # Specify the number of figures that can be built in parallel, with
     # a value of zero indicating one per cpu (default is one per cpu).
-    SASMODELS_BUILD_CPUS=0
+    # Don't use too large a value since it won't help (sasmodels already
+    # uses all available processors when calculating a model) and it may
+    # overwhelm the GPU if you have one.
+    SASMODELS_BUILD_CPUS=4

--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -60,7 +60,7 @@ Docs are built by changing into the doc directory and typing::
 The model figure generation is controlled by a environment variables::
 
     # Cache figures in /tmp to avoid rebuilding after "clean" (default is none)
-    SASMODELS_BUILD_CACHE=/tmp/sascache_$(shasum genmodels.py)
+    SASMODELS_BUILD_CACHE=/tmp/sascache_$(shasum genmodels.py | cut -f1 -d" ")
 
     # Specify the number of figures that can be built in parallel, with
     # a value of zero indicating one per cpu (default is one per cpu).

--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -52,3 +52,16 @@ here.  It will be easiest to install the package in "develop" mode using::
 
 This will allow you to edit the files in the package and have the changes
 show up immediately in python the next time you load your program.
+
+Docs are built by changing into the doc directory and typing::
+
+    $ make clean html
+
+The model figure generation is controlled by a environment variables::
+
+    # Cache figures in /tmp to avoid rebuilding after "clean" (default is none)
+    SASMODELS_BUILD_CACHE=/tmp/sascache_$(shasum genmodels.py)
+
+    # Specify the number of figures that can be built in parallel, with
+    # a value of zero indicating one per cpu (default is one per cpu).
+    SASMODELS_BUILD_CPUS=0

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -1253,17 +1253,6 @@ To check whether single precision is good enough, type the following::
 This will pop up a plot showing the difference between single precision
 and double precision on a range of $q$ values.
 
-::
-
-  demo = dict(scale=1, background=0,
-              sld=6, sld_solvent=1,
-              radius=120,
-              radius_pd=.2, radius_pd_n=45)
-
-**demo={'par': value, ...}** in the model file sets the default values for
-the comparison. You can include polydispersity parameters such as
-*radius_pd=0.2, radius_pd_n=45* which would otherwise be zero.
-
 These commands can also be run directly in the python interpreter:
 
     $ python -m sasmodels.model_test -v ~/.sasview/plugin_models/model.py
@@ -1284,10 +1273,11 @@ For the random models,
 - angles (*theta, phi, psi*) will be in the range (-180,180),
 - angular dispersion will be in the range (0,45),
 - polydispersity will be in the range (0,1)
-- other values will be in the range (0, 2\ *v*), where *v* is the value
-  of the parameter in demo.
+- other values will be in the range (0, 2\ *v*), where *v* is the default
+  parameter value.
 
-Dispersion parameters *n*\, *sigma* and *type* will be unchanged from
+Dispersion parameters *n*\, *sigma* and *type* will be set to random
+values if "-poly" is included on the command line.  be unchanged from
 demo so that run times are more predictable (polydispersity calculated
 across multiple parameters can be very slow).
 

--- a/explore/sc.py
+++ b/explore/sc.py
@@ -139,16 +139,6 @@ parameters = [["dnn",         "Ang",       220.0, [0.0, inf],  "",            "N
 
 source = ["lib/sas_3j1x_x.c", "lib/sphere_form.c", "lib/gauss150.c", "sc.c"]
 
-demo = dict(scale=1, background=0,
-            dnn=220.0,
-            d_factor=0.06,
-            radius=40.0,
-            sld=3.0,
-            sld_solvent=6.3,
-            theta=0.0,
-            phi=0.0,
-            psi=0.0)
-
 tests = [
     # Accuracy tests based on content in test/utest_extra_models.py, 2d tests added April 10, 2017
     [{}, 0.001, 10.3048],

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -84,13 +84,13 @@ Options (* for default):
     -preset*/-random[=seed] preset or random parameters
     -sets=n generates n random datasets with the seed given by -random=seed
     -pars/-nopars* prints the parameter set or not
-    -default/-demo* use demo vs default parameters
     -sphere[=150] set up spherical integration over theta/phi using n points
+    -mono*/-poly suppress or allow polydispersity on generated parameters
+    -magnetic/-nonmagnetic* suppress or allow magnetism on generated parameters
+    -maxdim[=inf] limit randomly generate particle dimensions to maxdim
 
     === calculation options ===
-    -mono*/-poly force monodisperse or allow polydisperse random parameters
     -cutoff=1e-5* cutoff value for including a point in polydispersity
-    -magnetic/-nonmagnetic* suppress magnetism
     -accuracy=Low accuracy of the resolution calculation Low, Mid, High, Xhigh
     -neval=1 sets the number of evals for more accurate timing
     -ngauss=0 overrides the number of points in the 1-D gaussian quadrature
@@ -112,6 +112,11 @@ Options (* for default):
     === output options ===
     -edit starts the parameter explorer
     -help/-html shows the model docs instead of running the model
+
+    === help ===
+    -h/-? print this help
+    -models[=all] show all builtin models of a given type:
+        all, py, c, double, single, opencl, 1d, 2d, magnetic
 
     === environment variables ===
     -DSAS_MODELPATH=~/.sasmodels/custom_models sets path to custom models
@@ -364,7 +369,6 @@ def _randomize_one(model_info, name, value):
         return np.random.uniform(*par.limits)
 
     # If the paramter is marked as an sld use the range of neutron slds
-    # TODO: ought to randomly contrast match a pair of SLDs
     if par.type == 'sld':
         return np.random.uniform(-0.5, 12)
 
@@ -387,7 +391,7 @@ def _randomize_one(model_info, name, value):
     limits = (max(par.limits[0], low), min(par.limits[1], high))
     return np.random.uniform(*limits)
 
-def _random_pd(model_info, pars):
+def _random_pd(model_info, pars, is2d):
     # type: (ModelInfo, Dict[str, float]) -> None
     """
     Generate a random dispersity distribution for the model.
@@ -400,42 +404,82 @@ def _random_pd(model_info, pars):
     If oriented, then put dispersity in theta, add phi and psi dispersity
     with 10% probability for each.
     """
+    # Find the polydisperse parameters.
     pd = [p for p in model_info.parameters.kernel_parameters if p.polydisperse]
-    pd_volume = []
-    pd_oriented = []
-    for p in pd:
-        if p.type == 'orientation':
-            pd_oriented.append(p.name)
-        elif p.length_control is not None:
-            n = int(pars.get(p.length_control, 1) + 0.5)
-            pd_volume.extend(p.name+str(k+1) for k in range(n))
-        elif p.length > 1:
-            pd_volume.extend(p.name+str(k+1) for k in range(p.length))
-        else:
-            pd_volume.append(p.name)
-    u = np.random.rand()
-    n = len(pd_volume)
-    if u < 0.01 or n < 1:
-        pass  # 1% chance of no polydispersity
-    elif u < 0.86 or n < 2:
-        pars[np.random.choice(pd_volume)+"_pd_n"] = 35
-    elif u < 0.99 or n < 3:
-        choices = np.random.choice(len(pd_volume), size=2)
-        pars[pd_volume[choices[0]]+"_pd_n"] = 25
-        pars[pd_volume[choices[1]]+"_pd_n"] = 10
-    else:
-        choices = np.random.choice(len(pd_volume), size=3)
-        pars[pd_volume[choices[0]]+"_pd_n"] = 25
-        pars[pd_volume[choices[1]]+"_pd_n"] = 10
-        pars[pd_volume[choices[2]]+"_pd_n"] = 5
-    if pd_oriented:
-        pars['theta_pd_n'] = 20
+
+    # If the sample is oriented then add polydispersity to the orientation.
+    oriented = any(p.type == 'orientation' for p in pd)
+    num_oriented_pd = 0
+    if oriented:
+        if np.random.rand() < 0.8:
+            # 80% change of pd on long axis (20x cost)
+            pars['theta_pd_n'] = 20
+            num_oriented_pd += 1
         if np.random.rand() < 0.1:
+            # 10% change of pd on short axis (5x cost)
             pars['phi_pd_n'] = 5
-        if np.random.rand() < 0.1:
-            if any(p.name == 'psi' for p in model_info.parameters.kernel_parameters):
-                #print("generating psi_pd_n")
-                pars['psi_pd_n'] = 5
+            num_oriented_pd += 1
+        if any(p.name == 'psi' for p in pd) and np.random.rand() < 0.1:
+            # 10% change of pd on spin axis (5x cost)
+            #print("generating psi_pd_n")
+            pars['psi_pd_n'] = 5
+            num_oriented_pd += 1
+
+    # Process non-orientation parameters
+    pd = [p for p in pd if p.type != 'orientation']
+
+    # Find the remaining pd parameters, which are all volume parameters.
+    # Use the parameter value as the weight on the choice function for
+    # the polydispersity parameter. The I(Q) curve is more sensitive to
+    # pd on larger dimensions, so they should be preferred.
+    # TODO: choose better weights for parameters like num_pearls or num_disks.
+    name = [] # type: List[str]  # name of the next volume parameter
+    default = [] # type: List[float]  # default val for that volume parameter
+    for p in pd:
+        if p.length_control is not None:
+            slots = int(pars.get(p.length_control, 1) + 0.5)
+            name.extend(p.name+str(k+1) for k in range(slots))
+            default.extend(p.default for k in range(slots))
+        elif p.length > 1:
+            slots = p.length
+            name.extend(p.name+str(k+1) for k in range(slots))
+            default.extend(p.default for k in range(slots))
+        else:
+            name.append(p.name)
+            default.append(p.default)
+    p = [pars.get(k, v) for k, v in zip(name, default)]  # relative weight
+    p = np.array(p)/sum(p) if p else []  # normalize to probability
+
+    # Select number of pd parameters to use.  The selection is biased
+    # toward fewer pd parameters if there is already orientational pd
+    # (effectively allowing only one volume pd) and the number of pd steps
+    # is scaled down.  Ignore oriented if it is not 2d data.
+    if not is2d:
+        num_oriented_pd = 0
+    n = len(name)
+    u = np.random.rand()
+    if u < (1 - 1/(1+num_oriented_pd)):
+        # if lots of orientation dispersity then reject shape dispersity
+        pass
+    elif u < 0.01 or n < 1:
+        # 1% chance of no polydispersity (1x cost)
+        pass
+    elif u < 0.66 or n < 2:
+        # 65% chance of pd on one value (35x cost)
+        choice = np.random.choice(n, size=1, replace=False, p=p)
+        pars[name[choice[0]]+"_pd_n"] = 35 // (1 + num_oriented_pd)
+    elif u < 0.99 or n < 3:
+        # 33% chance of pd on two values (250x cost)
+        choice = np.random.choice(n, size=2, replace=False, p=p)
+        pars[name[choice[0]]+"_pd_n"] = 25 // (1 + num_oriented_pd)
+        pars[name[choice[1]]+"_pd_n"] = 10 // (1 + num_oriented_pd)
+    else:
+        # 1% chance of pd on three values (1250x cost)
+        choice = np.random.choice(n, size=3, replace=False, p=p)
+        pars[name[choice[0]]+"_pd_n"] = 25
+        pars[name[choice[1]]+"_pd_n"] = 10
+        pars[name[choice[2]]+"_pd_n"] = 5
+
 
     ## Show selected polydispersity
     #for name, value in pars.items():
@@ -443,8 +487,8 @@ def _random_pd(model_info, pars):
     #        print(name, value, pars.get(name[:-5], 0), pars.get(name[:-2], 0))
 
 
-def randomize_pars(model_info, pars):
-    # type: (ModelInfo, ParameterSet) -> ParameterSet
+def randomize_pars(model_info, pars, maxdim=np.inf, is2d=False):
+    # type: (ModelInfo, ParameterSet, float) -> ParameterSet
     """
     Generate random values for all of the parameters.
 
@@ -458,7 +502,8 @@ def randomize_pars(model_info, pars):
                        for p, v in sorted(pars.items()))
     if model_info.random is not None:
         random_pars.update(model_info.random())
-    _random_pd(model_info, random_pars)
+    _random_pd(model_info, random_pars, is2d)
+    limit_dimensions(model_info, random_pars, maxdim)
     return random_pars
 
 
@@ -471,6 +516,27 @@ def limit_dimensions(model_info, pars, maxdim):
         value = pars[p.name]
         if p.units == 'Ang' and value > maxdim:
             pars[p.name] = maxdim*10**np.random.uniform(-3, 0)
+
+def _swap_pars(pars, a, b):
+    # type: (ModelInfo, str, str) -<> None
+    """
+    Swap polydispersity and magnetism when swapping parameters.
+
+    Assume the parameters are of the same basic type (volume, sld, or other),
+    so that if, for example, radius_pd is in pars but radius_bell_pd is not,
+    then after the swap radius_bell_pd will be the old radius_pd and radius_pd
+    will be removed.
+    """
+    for ext in ("", "_pd", "_pd_n", "_pd_nsigma", "_pd_type", "_M0", "_mphi", "_mtheta"):
+        ax, bx = a+ext, b+ext
+        if ax in pars and bx in pars:
+            pars[ax], pars[bx] = pars[bx], pars[ax]
+        elif ax in pars:
+            pars[bx] = pars[ax]
+            del pars[ax]
+        elif bx in pars:
+            pars[ax] = pars[bx]
+            del pars[bx]
 
 def constrain_pars(model_info, pars):
     # type: (ModelInfo, ParameterSet) -> None
@@ -496,11 +562,11 @@ def constrain_pars(model_info, pars):
 
     if name == 'barbell':
         if pars['radius_bell'] < pars['radius']:
-            pars['radius'], pars['radius_bell'] = pars['radius_bell'], pars['radius']
+            _swap_pars(pars, 'radius_bell', 'radius')
 
     elif name == 'capped_cylinder':
         if pars['radius_cap'] < pars['radius']:
-            pars['radius'], pars['radius_cap'] = pars['radius_cap'], pars['radius']
+            _swap_pars(pars, 'radius_cap', 'radius')
 
     elif name == 'guinier':
         # Limit guinier to an Rg such that Iq > 1e-30 (single precision cutoff)
@@ -515,7 +581,7 @@ def constrain_pars(model_info, pars):
 
     elif name == 'pearl_necklace':
         if pars['radius'] < pars['thick_string']:
-            pars['radius'], pars['thick_string'] = pars['thick_string'], pars['radius']
+            _swap_pars(pars, 'thick_string', 'radius')
 
     elif name == 'rpa':
         # Make sure phi sums to 1.0
@@ -533,16 +599,17 @@ def parlist(model_info, pars, is2d):
     """
     Format the parameter list for printing.
     """
-    is2d = True
     lines = []
     parameters = model_info.parameters
     magnetic = False
     magnetic_pars = []
-    for p in parameters.user_parameters(pars, is2d):
+    for p in parameters.user_parameters(pars, True):
         if any(p.id.endswith(x) for x in ('_M0', '_mtheta', '_mphi')):
             continue
-        if p.id.startswith('up:'):
+        if p.id in set(('up_frac_i', 'up_frac_f', 'up_angle')):
             magnetic_pars.append("%s=%s"%(p.id, pars.get(p.id, p.default)))
+            continue
+        if not is2d and p.id in ('theta', 'phi', 'psi'):
             continue
         fields = dict(
             value=pars.get(p.id, p.default),
@@ -576,63 +643,27 @@ def _format_par(name, value=0., pd=0., n=0, nsigma=3., pdtype='gaussian',
         line += "  M0:%.3f  mtheta:%.1f  mphi:%.1f" % (M0, mtheta, mphi)
     return line
 
-def suppress_pd(pars, suppress=True):
+def suppress_pd(pars):
     # type: (ParameterSet) -> ParameterSet
     """
-    If suppress is True complete eliminate polydispersity of the model to test
-    models more quickly.  If suppress is False, make sure at least one
-    parameter is polydisperse, setting the first polydispersity parameter to
-    15% if no polydispersity is given (with no explicit demo parameters given
-    in the model, there will be no default polydispersity).
+    Complete eliminate polydispersity of the model to test models more quickly.
     """
     pars = pars.copy()
-    #print("pars=", pars)
-    if suppress:
-        for p in pars:
-            if p.endswith("_pd_n"):
-                pars[p] = 0
-    else:
-        any_pd = False
-        first_pd = None
-        for p in pars:
-            if p.endswith("_pd_n"):
-                pd = pars.get(p[:-2], 0.)
-                any_pd |= (pars[p] != 0 and pd != 0.)
-                if first_pd is None:
-                    first_pd = p
-        if not any_pd and first_pd is not None:
-            if pars[first_pd] == 0:
-                pars[first_pd] = 35
-            if first_pd[:-2] not in pars or pars[first_pd[:-2]] == 0:
-                pars[first_pd[:-2]] = 0.15
+    for p in pars:
+        if p.endswith("_pd_n"):
+            pars[p] = 0
     return pars
 
-def suppress_magnetism(pars, suppress=True):
+def suppress_magnetism(pars):
     # type: (ParameterSet) -> ParameterSet
     """
-    If suppress is True complete eliminate magnetism of the model to test
-    models more quickly.  If suppress is False, make sure at least one sld
-    parameter is magnetic, setting the first parameter to have a strong
-    magnetic sld (8/A^2) at 60 degrees (with no explicit demo parameters given
-    in the model, there will be no default magnetism).
+    Complete eliminate magnetism of the model to test models more quickly.
     """
     pars = pars.copy()
-    if suppress:
-        for p in pars:
-            if p.endswith("_M0"):
-                pars[p] = 0
-    else:
-        any_mag = False
-        first_mag = None
-        for p in pars:
-            if p.endswith("_M0"):
-                any_mag |= (pars[p] != 0)
-                if first_mag is None:
-                    first_mag = p
-        if not any_mag and first_mag is not None:
-            pars[first_mag] = 8.
+    for p in pars:
+        if p.endswith("_M0"):
+            pars[p] = 0
     return pars
-
 
 def time_calculation(calculator, pars, evals=1):
     # type: (Calculator, ParameterSet, int) -> Tuple[np.ndarray, float]
@@ -751,20 +782,23 @@ def _show_invalid(data, theory):
         print("   *** ", ", ".join("I(%g)=%g"%(x, y) for x, y in bad))
 
 
-def compare(opts, limits=None, maxdim=np.inf):
+def compare(opts, limits=None, maxdim=None):
     # type: (Dict[str, Any], Optional[Tuple[float, float]]) -> Tuple[float, float]
     """
     Preform a comparison using options from the command line.
 
-    *limits* are the limits on the values to use, either to set the y-axis
+    *limits* are the display limits on the graph, either to set the y-axis
     for 1D or to set the colormap scale for 2D.  If None, then they are
     inferred from the data and returned. When exploring using Bumps,
     the limits are set when the model is initially called, and maintained
     as the values are adjusted, making it easier to see the effects of the
     parameters.
 
-    *maxdim* is the maximum value for any parameter with units of Angstrom.
+    *maxdim* **DEPRECATED** Use opts['maxdim'] instead.
     """
+    # CRUFT: remove maxdim parameter
+    if maxdim is not None:
+        opts['maxdim'] = maxdim
     for k in range(opts['sets']):
         if k > 0:
             # print a separate seed for each dataset for better reproducibility
@@ -1021,14 +1055,14 @@ OPTIONS = [
 
     # Parameter set
     'preset', 'random', 'random=', 'sets=',
-    'demo', 'default',  # TODO: remove demo/default
     'nopars', 'pars',
     'sphere', 'sphere=', # integrate over a sphere in 2d with n points
+    'poly', 'mono',
+    'magnetic', 'nonmagnetic',
+    'maxdim=',
 
     # Calculation options
-    'poly', 'mono', 'cutoff=',
-    'magnetic', 'nonmagnetic',
-    'accuracy=', 'ngauss=',
+    'cutoff=', 'accuracy=', 'ngauss=',
     'neval=',  # for timing...
 
     # Precision options
@@ -1037,19 +1071,33 @@ OPTIONS = [
 
     # Output options
     'help', 'html', 'edit',
+
+    # Help options
+    'h', '?', 'models', 'models='
     ]
 
 NAME_OPTIONS = (lambda: set(k for k in OPTIONS if not k.endswith('=')))()
 VALUE_OPTIONS = (lambda: [k[:-1] for k in OPTIONS if k.endswith('=')])()
 
 
-def columnize(items, indent="", width=79):
+def columnize(items, indent="", width=None):
     # type: (List[str], str, int) -> str
     """
     Format a list of strings into columns.
 
     Returns a string with carriage returns ready for printing.
     """
+    # Use the columnize package (pycolumize) if it is available
+    try:
+        from columnize import columnize as _columnize, default_opts
+        if width is None:
+            width = default_opts['displaywidth']
+        return _columnize(list(items), displaywidth=width, lineprefix=indent)
+    except ImportError:
+        pass
+    # Otherwise roll our own.
+    if width is None:
+        width = 120
     column_width = max(len(w) for w in items) + 1
     num_columns = (width - len(indent)) // column_width
     num_rows = len(items) // num_columns
@@ -1061,10 +1109,10 @@ def columnize(items, indent="", width=79):
     return output
 
 
-def get_pars(model_info, use_demo=False):
+def get_pars(model_info):
     # type: (ModelInfo, bool) -> ParameterSet
     """
-    Extract demo parameters from the model definition.
+    Extract default parameters from the model definition.
     """
     # Get the default values for the parameters
     pars = {}
@@ -1081,10 +1129,6 @@ def get_pars(model_info, use_demo=False):
                      for k in range(1, p.length+1))
             else:
                 pars[p.id + ext] = val
-
-    # Plug in values given in demo
-    if use_demo and model_info.demo:
-        pars.update(model_info.demo)
     return pars
 
 INTEGER_RE = re.compile("^[+-]?[1-9][0-9]*$")
@@ -1094,6 +1138,13 @@ def isnumber(s):
     match = FLOAT_RE.match(s)
     isfloat = (match and not s[match.end():])
     return isfloat or INTEGER_RE.match(s)
+
+def print_models(kind=None):
+    """
+    Print the list of available models in columns.
+    """
+    models = core.list_models(kind=kind)
+    print(columnize(models, indent="  "))
 
 # For distinguishing pairs of models for comparison
 # key-value pair separator =
@@ -1109,32 +1160,50 @@ def parse_opts(argv):
     """
     Parse command line options.
     """
-    MODELS = core.list_models()
+
     flags = [arg for arg in argv
              if arg.startswith('-')]
     values = [arg for arg in argv
               if not arg.startswith('-') and '=' in arg]
     positional_args = [arg for arg in argv
                        if not arg.startswith('-') and '=' not in arg]
-    models = "\n    ".join("%-15s"%v for v in MODELS)
-    if len(positional_args) == 0:
+
+    # First check if help requested anywhere on line
+    if '-h' in flags or '-?' in flags:
         print(USAGE)
-        print("\nAvailable models:")
-        print(columnize(MODELS, indent="  "))
         return None
 
+    # Next check that all flags are valid.
     invalid = [o[1:] for o in flags
                if not (o[1:] in NAME_OPTIONS
                        or any(o.startswith('-%s='%t) for t in VALUE_OPTIONS)
                        or o.startswith('-D'))]
     if invalid:
-        print("Invalid options: %s"%(", ".join(invalid)))
+        print("Invalid options: %s."%(", ".join(invalid)))
+        print("usage: ./sasmodels [-?] [-models] model")
         return None
 
+    # Check if requesting a list of models.  This is done after checking that
+    # the flags are valid so we know it is -models or -models=.
+    if any(v.startswith('-models') for v in flags):
+        # grab last -models entry
+        models = [v for v in flags if v.startswith('-models')][-1]
+        if models == '-models':
+            models = '-models=all'
+        _, kind = models.split('=', 1)
+        print_models(kind=kind)
+        return None
+
+    # Check that a model was given on the command line
+    if len(positional_args) == 0:
+        print("usage: ./sascomp [-?] [-models] model")
+        return None
+
+    # Only the last model on the command line is used.
     name = positional_args[-1]
 
-    # pylint: disable=bad-whitespace,C0321
     # Interpret the flags
+    # pylint: disable=bad-whitespace,C0321
     opts = {
         'plot'      : True,
         'view'      : 'log',
@@ -1150,11 +1219,11 @@ def parse_opts(argv):
         'mono'      : True,
         # Default to magnetic a magnetic moment is set on the command line
         'magnetic'  : False,
+        'maxdim'    : np.inf,
         'show_pars' : False,
         'show_hist' : False,
         'rel_err'   : True,
         'explore'   : False,
-        'use_demo'  : False,
         'zero'      : False,
         'html'      : False,
         'title'     : None,
@@ -1202,6 +1271,8 @@ def parse_opts(argv):
         elif arg.startswith('-sphere'):
             opts['sphere'] = int(arg[8:]) if len(arg) > 7 else 150
             opts['is2d'] = True
+        elif arg.startswith('-maxdim'):
+            opts['maxdim'] = float(arg[8:])
         elif arg == '-preset':  opts['seed'] = -1
         elif arg == '-mono':    opts['mono'] = True
         elif arg == '-poly':    opts['mono'] = False
@@ -1221,8 +1292,6 @@ def parse_opts(argv):
         elif arg == '-double!': opts['engine'] = 'double!'
         elif arg == '-quad!':   opts['engine'] = 'quad!'
         elif arg == '-edit':    opts['explore'] = True
-        elif arg == '-demo':    opts['use_demo'] = True
-        elif arg == '-default': opts['use_demo'] = False
         elif arg == '-weights': opts['show_weights'] = True
         elif arg == '-profile': opts['show_profile'] = True
         elif arg == '-html':    opts['html'] = True
@@ -1256,8 +1325,8 @@ def parse_opts(argv):
     try:
         model_info = [core.load_model_info(k) for k in names]
     except ImportError as exc:
-        print(str(exc))
-        print("Could not find model; use one of:\n    " + models)
+        print(str(exc), "while loading", names)
+        print("usage: ./sasmodels [-?] [-models] model")
         return None
 
     if PAR_SPLIT in opts['ngauss']:
@@ -1357,33 +1426,74 @@ def set_spherical_integration_parameters(opts, steps):
             'psi_pd_type=rectangle',
         ])
 
-def parse_pars(opts, maxdim=np.inf):
+def parse_pars(opts, maxdim=None):
     # type: (Dict[str, Any], float) -> Tuple[Dict[str, float], Dict[str, float]]
     """
-    Generate a parameter set.
+    Generate parameter sets for base and comparison models.
 
-    The default values come from the model, or a randomized model if a seed
-    value is given.  Next, evaluate any parameter expressions, constraining
-    the value of the parameter within and between models.  If *maxdim* is
-    given, limit parameters with units of Angstrom to this value.
+    Returns a pair of parameter dictionaries.
 
-    Returns a pair of parameter dictionaries for base and comparison models.
+    The default parameter values come from the model, or a randomized model
+    if a seed value is given.  Next, evaluate any parameter expressions,
+    constraining the value of the parameter within and between models.
+
+    Note: When generating random parameters, **the seed must already be set**
+    with a call to *np.random.seed(opts['seed'])*.
+
+    *opts* controls the parameter generation::
+
+        opts = {
+            'info': (model_info 1, model_info 2),
+            'seed': -1,         # if seed>=0 then randomize parameters
+            'mono': False,      # force monodisperse random parameters
+            'magnetic': False,  # force nonmagetic random parameters
+            'maxdim': np.inf,   # limit particle size to maxdim for random pars
+            'values': ['par=expr', ...],  # override parameter values in model
+            'show_pars': False, # Show parameter values
+            'is2d': False,      # Show values for orientation parameters
+        }
+
+    The values of *par=expr* are evaluated approximately as::
+
+        import numpy as np
+        from math import *
+        from parameter_set import *
+
+        parameter_set.par = eval(expr)
+
+    That is, you can use arbitrary python math expressions including the
+    functions defined in the math library and the numpy library.  You can
+    also use the existing parameter values, which will either be the model
+    defaults or the randomly generated values if seed is non-negative.
+
+    To compare different values of the same parameter, use *par=expr,expr*.
+    The first parameter set will have the values from the first expression
+    and the second parameter set will have the values from the second
+    expression.  Note that the second expression is evaluated using the
+    values from the first expression, which allows things like::
+
+        length=2*radius,length+3
+
+    which will compare length to length+3 when length is set to 2*radius.
+
+    *maxdim* **DEPRECATED** Use *opts['maxdim']* instead.
     """
+    # CRUFT: maxdim parameter is deprecated
+    if maxdim is not None:
+        opts['maxdim'] = maxdim
+
     model_info, model_info2 = opts['info']
 
-    # Get demo parameters from model definition, or use default parameters
-    # if model does not define demo parameters
-    pars = get_pars(model_info, opts['use_demo'])
-    pars2 = get_pars(model_info2, opts['use_demo'])
+    # Get default parameters from model definition.
+    pars = get_pars(model_info)
+    pars2 = get_pars(model_info2)
     pars2.update((k, v) for k, v in pars.items() if k in pars2)
     # randomize parameters
     #pars.update(set_pars)  # set value before random to control range
     if opts['seed'] > -1:
-        pars = randomize_pars(model_info, pars)
-        limit_dimensions(model_info, pars, maxdim)
-        if model_info != model_info2:
-            pars2 = randomize_pars(model_info2, pars2)
-            limit_dimensions(model_info2, pars2, maxdim)
+        pars = randomize_pars(model_info, pars, maxdim=opts['maxdim'])
+        if model_info.id != model_info2.id:
+            pars2 = randomize_pars(model_info2, pars2, maxdim=opts['maxdim'])
             # Share values for parameters with the same name
             for k, v in pars.items():
                 if k in pars2:
@@ -1392,10 +1502,15 @@ def parse_pars(opts, maxdim=np.inf):
             pars2 = pars.copy()
         constrain_pars(model_info, pars)
         constrain_pars(model_info2, pars2)
-    pars = suppress_pd(pars, opts['mono'])
-    pars2 = suppress_pd(pars2, opts['mono'])
-    pars = suppress_magnetism(pars, not opts['magnetic'])
-    pars2 = suppress_magnetism(pars2, not opts['magnetic'])
+        # TODO: randomly contrast match a pair of SLDs with some probability
+
+    # Process -mono and -magnetic command line options.
+    if opts['mono']:
+        pars = suppress_pd(pars)
+        pars2 = suppress_pd(pars2)
+    if not opts['magnetic']:
+        pars = suppress_magnetism(pars)
+        pars2 = suppress_magnetism(pars2)
 
     # Fill in parameters given on the command line
     presets = {}
@@ -1445,9 +1560,9 @@ def parse_pars(opts, maxdim=np.inf):
 
     # Hack to load user-defined distributions; run through all parameters
     # and make sure any pd_type parameter is a defined distribution.
-    if (any(p.endswith('pd_type') and v not in weights.MODELS
+    if (any(p.endswith('pd_type') and v not in weights.DISTRIBUTIONS
             for p, v in pars.items()) or
-        any(p.endswith('pd_type') and v not in weights.MODELS
+        any(p.endswith('pd_type') and v not in weights.DISTRIBUTIONS
             for p, v in pars2.items())):
        weights.load_weights()
 

--- a/sasmodels/compare_many.py
+++ b/sasmodels/compare_many.py
@@ -19,9 +19,9 @@ import traceback
 import numpy as np  # type: ignore
 
 from . import core
-from .compare import (randomize_pars, suppress_pd, make_data,
-                      make_engine, get_pars, columnize,
-                      constrain_pars)
+from .compare import (
+    randomize_pars, suppress_pd, make_data, make_engine, get_pars, columnize,
+    constrain_pars, print_models)
 
 MODELS = core.list_models()
 
@@ -101,7 +101,7 @@ def compare_instance(name, data, index, N=1, mono=True, cutoff=1e-5,
 
     is_2d = hasattr(data, 'qx_data')
     model_info = core.load_model_info(name)
-    pars = get_pars(model_info, use_demo=True)
+    pars = get_pars(model_info)
     header = ('\n"Model","%s","Count","%d","Dimension","%s"'
               % (name, N, "2D" if is_2d else "1D"))
     if not mono:
@@ -190,13 +190,6 @@ def print_usage():
           file=sys.stderr)
 
 
-def print_models():
-    """
-    Print the list of available models in columns.
-    """
-    print(columnize(MODELS, indent="  "))
-
-
 def print_help():
     """
     Print usage string, the option description and the list of available models.
@@ -221,17 +214,13 @@ values are "1d100" for 1-D and "2d32" for 2-D.
 CUTOFF is the cutoff value to use for the polydisperse distribution. Weights
 below the cutoff will be ignored.  Use "mono" for monodisperse models.  The
 choice of polydisperse parameters, and the number of points in the distribution
-is set in compare.py defaults for each model.  Polydispersity is given in the
-"demo" attribute of each model.
+is set in compare.py defaults for each model.
 
 PRECISION is the floating point precision to use for comparisons.  If two
 precisions are given, then compare one to the other.  Precision is one of
 fast, single, double for GPU or single!, double!, quad! for DLL.  If no
 precision is given, then use single and double! respectively.
-
-Available models:
 """)
-    print_models()
 
 def main(argv):
     """
@@ -245,9 +234,12 @@ def main(argv):
     try:
         model_list = [target] if target in MODELS else core.list_models(target)
     except ValueError:
-        print('Bad model %s.  Use model type or one of:' % target, file=sys.stderr)
-        print_models()
-        print('model types: all, py, c, double, single, opencl, 1d, 2d, nonmagnetic, magnetic')
+        msg = """\
+Bad model {target}. Use available model or model type.
+  available models: ./sascomp -models
+  model types: all, py, c, double, single, opencl, 1d, 2d, nonmagnetic, magnetic\
+""".format(target=target)
+        print(msg, file=sys.stderr)
         return
     try:
         count = int(argv[1])

--- a/sasmodels/core.py
+++ b/sasmodels/core.py
@@ -16,14 +16,13 @@ import copy
 
 import numpy as np # type: ignore
 
+# NOTE: delay loading of kernelcl, kernelcuda, kerneldll and kernelpy
+# cl and cuda in particular take awhile since they try to establish a
+# connection with the card to verify that the environment works.
 from . import generate
 from . import modelinfo
 from . import product
 from . import mixture
-from . import kernelpy
-from . import kernelcuda
-from . import kernelcl
-from . import kerneldll
 from . import custom
 
 # pylint: disable=unused-import
@@ -329,16 +328,20 @@ def build_model(model_info, dtype=None, platform="ocl"):
 
     # If it is a python model, return it immediately
     if callable(model_info.Iq):
+        from . import kernelpy
         return kernelpy.PyModel(model_info)
 
     numpy_dtype, fast, platform = parse_dtype(model_info, dtype, platform)
     source = generate.make_source(model_info)
     if platform == "dll":
+        from . import kerneldll
         #print("building dll", numpy_dtype)
         return kerneldll.load_dll(source['dll'], model_info, numpy_dtype)
     elif platform == "cuda":
+        from . import kernelcuda
         return kernelcuda.GpuModel(source, model_info, numpy_dtype, fast=fast)
     else:
+        from . import kernelcl
         #print("building ocl", numpy_dtype)
         return kernelcl.GpuModel(source, model_info, numpy_dtype, fast=fast)
 
@@ -353,6 +356,8 @@ def precompile_dlls(path, dtype="double"):
     This can be used when build the windows distribution of sasmodels
     which may be missing the OpenCL driver and the dll compiler.
     """
+    from . import kerneldll
+
     numpy_dtype = np.dtype(dtype)
     if not os.path.exists(path):
         os.makedirs(path)
@@ -409,8 +414,11 @@ def parse_dtype(model_info, dtype=None, platform=None):
         platform = "dll"
 
     # Make sure opencl is available, or fallback to cuda then to dll
-    if platform == "ocl" and not kernelcl.use_opencl():
-        platform = "cuda" if kernelcuda.use_cuda() else "dll"
+    if platform == "ocl":
+        from . import kernelcl
+        if not kernelcl.use_opencl():
+            from . import kernelcuda
+            platform = "cuda" if kernelcuda.use_cuda() else "dll"
 
     # Convert special type names "half", "fast", and "quad"
     fast = (dtype == "fast")
@@ -431,8 +439,10 @@ def parse_dtype(model_info, dtype=None, platform=None):
 
     # Make sure that the type is supported by GPU, otherwise use dll
     if platform == "ocl":
+        from . import kernelcl
         env = kernelcl.environment()
     elif platform == "cuda":
+        from . import kernelcuda
         env = kernelcuda.environment()
     else:
         env = None

--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -107,12 +107,6 @@ The kernel module must set variables defining the kernel meta data:
     cylinder models).  The expression can call C functions, including
     those defined in your model file.
 
-    **DEPRECATED** *demo* is a dictionary of parameter=value defining a set of
-    parameters to use by default when *compare* is called.  Any
-    parameter not set in *demo* gets the initial value from the
-    parameter list.  *demo* is mostly needed to set the default
-    polydispersity values for tests.
-
 A :class:`modelinfo.ModelInfo` structure is constructed from the kernel meta
 data and returned to the caller.
 

--- a/sasmodels/kernel.py
+++ b/sasmodels/kernel.py
@@ -41,6 +41,7 @@ class KernelModel(object):
         """
         Free resources associated with the kernel.
         """
+        #print("null release model")
         pass
 
 
@@ -177,6 +178,7 @@ class Kernel(object):
         """
         Free resources associated with the kernel instance.
         """
+        #print("null release kernel")
         pass
 
     def _call_kernel(self, call_details, values, cutoff, magnetic,

--- a/sasmodels/kernelcl.py
+++ b/sasmodels/kernelcl.py
@@ -421,10 +421,12 @@ class GpuModel(KernelModel):
 
     def __init__(self, source, model_info, dtype=generate.F32, fast=False):
         # type: (Dict[str,str], ModelInfo, np.dtype, bool) -> None
+        #print("create model", id(self))
         self.info = model_info
         self.source = source
         self.dtype = dtype
         self.fast = fast
+        # TODO: can a model be freed?
 
     def __getstate__(self):
         # type: () -> Tuple[ModelInfo, str, np.dtype, bool]
@@ -487,12 +489,22 @@ class GpuInput(object):
     Call :meth:`release` when complete.  Even if not called directly, the
     buffer will be released when the data object is freed.
     """
+    nq = 0
+    dtype = generate.F32
+    is_2d = False
+    q = None
+    q_b = None
     def __init__(self, q_vectors, dtype=generate.F32):
         # type: (List[np.ndarray], np.dtype) -> None
+        #print("create input", id(self))
         # TODO: Do we ever need double precision q?
         self.nq = q_vectors[0].size
         self.dtype = np.dtype(dtype)
         self.is_2d = (len(q_vectors) == 2)
+        if self.nq == 0:
+            raise ValueError("GpuInput vector length must be greater than zero")
+        if self.is_2d and q_vectors[1].shape != q_vectors[0].shape:
+            raise ValueError("GpuInput vectors must be the same shape")
         # TODO: Stretch input based on get_warp().
         # Not doing it now since warp depends on kernel, which is not known
         # at this point, so instead using 32, which is good on the set of
@@ -520,12 +532,14 @@ class GpuInput(object):
         """
         Free the buffer associated with the q value.
         """
+        #print("release input", id(self))
         if self.q_b is not None:
             self.q_b.release()
             self.q_b = None
 
     def __del__(self):
         # type: () -> None
+        #print("input deleted", id(self))
         self.release()
 
 
@@ -551,9 +565,12 @@ class GpuKernel(Kernel):
     dim = ""  # type: str
     #: Calculation results, updated after each call to :meth:`_call_kernel`.
     result = None  # type: np.ndarray
+    q_input = None # type: GpuInput
+    _result_b = None # type: cl.Bufferj
 
     def __init__(self, model, q_vectors):
         # type: (GpuModel, List[np.ndarray]) -> None
+        #print("create kernel", id(self))
         dtype = model.dtype
         self.q_input = GpuInput(q_vectors, dtype)
         self._model = model
@@ -639,11 +656,15 @@ class GpuKernel(Kernel):
         """
         Release resources associated with the kernel.
         """
-        self.q_input.release()
+        #print("release kernel", id(self))
+        if self.q_input is not None:
+            self.q_input.release()
+            self.q_input = None
         if self._result_b is not None:
             self._result_b.release()
             self._result_b = None
 
     def __del__(self):
         # type: () -> None
+        #print("delete kernel", id(self))
         self.release()

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -46,7 +46,7 @@ MAX_PD = 5 #: Maximum number of simultaneously polydisperse parameters
 # depends on the some polydisperse parameter with the current implementation
 DEFAULT_BACKGROUND = 1e-3
 COMMON_PARAMETERS = [
-    ("scale", "", 1, (0.0, np.inf), "", "Source intensity"),
+    ("scale", "", 1, (0.0, np.inf), "", "Scale factor or Volume fraction"),
     ("background", "1/cm", DEFAULT_BACKGROUND, (-np.inf, np.inf), "", "Source background"),
 ]
 assert (len(COMMON_PARAMETERS) == 2

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -166,16 +166,16 @@ def parse_parameter(name, units='', default=np.NaN,
     return parameter
 
 
-def expand_pars(partable, pars):
+def expand_pars(partable, pars=None):
     # type: (ParameterTable, ParameterSetUser) ->  ParameterSet
     """
-    Create demo parameter set from key-value pairs.
+    Create a parameter set from key-value pairs.
 
     *pars* are the key-value pairs to use for the parameters.  Any
     parameters not specified in *pars* are set from the *partable* defaults.
 
     If *pars* references vector fields, such as thickness[n], then support
-    different ways of assigning the demo values, including assigning a
+    different ways of assigning the parameter values, including assigning a
     specific value (e.g., thickness3=50.0), assigning a new value to all
     (e.g., thickness=50.0) or assigning values using list notation.
     """
@@ -914,12 +914,6 @@ def make_model_info(kernel_module):
     if structure_factor:
         parameters.set_zero_background()
 
-    # TODO: remove demo parameters
-    # The plots in the docs are generated from the model default values.
-    # Sascomp set parameters from the command line, and so doesn't need
-    # demo values for testing.
-    demo = expand_pars(parameters, getattr(kernel_module, 'demo', None))
-
     filename = abspath(kernel_module.__file__).replace('.pyc', '.py')
     kernel_id = splitext(basename(filename))[0]
     name = getattr(kernel_module, 'name', None)
@@ -933,7 +927,6 @@ def make_model_info(kernel_module):
     info.description = getattr(kernel_module, 'description', 'no description')
     info.base = info.parameters = parameters
     info.translation = None
-    info.demo = demo
     info.composition = None
     info.docs = kernel_module.__doc__
     info.category = getattr(kernel_module, 'category', None)
@@ -1019,13 +1012,6 @@ class ModelInfo(object):
     #: Parameter translation code to convert from *parameters* table from
     #: caller to the *base* table used to evaluate the model.
     translation = None      # type: str
-    #: **DEPRECATED**
-    #: Demo parameters as a *parameter:value* map used as the default values
-    #: for :mod:`compare`.  Any parameters not set in *demo* will use the
-    #: defaults from the parameter table.  That means no polydispersity, and
-    #: in the case of multiplicity models, a minimal model with no interesting
-    #: scattering.
-    demo = None             # type: Dict[str, float]
     #: Composition is None if this is an independent model, or it is a
     #: tuple with comoposition type ('product' or 'misture') and a list of
     #: :class:`ModelInfo` blocks for the composed objects.  This allows us

--- a/sasmodels/models/_spherepy.py
+++ b/sasmodels/models/_spherepy.py
@@ -113,8 +113,3 @@ def sesans(z, sld, sld_solvent, radius):
               + dlow2/2.*(1 - dlow2/16.) * log(dlow / (2. + sqrt(4. - dlow2))))
     return g
 sesans.vectorized = True  # sesans accepts an array of z values
-
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            radius=120,
-            radius_pd=.2, radius_pd_n=45)

--- a/sasmodels/models/barbell.py
+++ b/sasmodels/models/barbell.py
@@ -144,16 +144,6 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            radius_bell=40, radius=20, length=400,
-            theta=60, phi=60,
-            radius_pd=.2, radius_pd_n=5,
-            length_pd=.2, length_pd_n=5,
-            theta_pd=15, theta_pd_n=0,
-            phi_pd=15, phi_pd_n=0,
-           )
 q = 0.1
 # 2017-04-06: rkh add unit tests, NOT compared with any other calc method, assume correct!
 # 2019-05-17: pak added barbell/capped cylinder to realspace sampling tests

--- a/sasmodels/models/be_polyelectrolyte.py
+++ b/sasmodels/models/be_polyelectrolyte.py
@@ -191,15 +191,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0.1,
-            contrast_factor=10.0,
-            bjerrum_length=7.1,
-            virial_param=12.0,
-            monomer_length=10.0,
-            salt_concentration=0.0,
-            ionization_degree=0.05,
-            polymer_concentration=0.7)
-
 tests = [
 
     # Accuracy tests based on content in test/utest_other_models.py

--- a/sasmodels/models/binary_hard_sphere.py
+++ b/sasmodels/models/binary_hard_sphere.py
@@ -131,10 +131,5 @@ def random():
     )
     return pars
 
-# parameters for demo and documentation
-demo = dict(sld_lg=3.5, sld_sm=0.5, sld_solvent=6.36,
-            radius_lg=100, radius_sm=20,
-            volfraction_lg=0.1, volfraction_sm=0.2)
-
 # NOTE: test results taken from values returned by SasView 3.1.2
 tests = [[{}, 0.001, 25.8927262013]]

--- a/sasmodels/models/broad_peak.py
+++ b/sasmodels/models/broad_peak.py
@@ -109,7 +109,3 @@ def random():
     pars['lorentz_scale'] *= pars['porod_scale'] / pars['peak_pos']**pars['porod_exp']
     #pars['porod_scale'] = 0.
     return pars
-
-demo = dict(scale=1, background=0,
-            porod_scale=1.0e-05, porod_exp=3,
-            lorentz_scale=10, lorentz_length=50, peak_pos=0.1, lorentz_exp=2)

--- a/sasmodels/models/capped_cylinder.py
+++ b/sasmodels/models/capped_cylinder.py
@@ -166,15 +166,6 @@ def random():
     return pars
 
 
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            radius=260, radius_cap=290, length=290,
-            theta=30, phi=15,
-            radius_pd=.2, radius_pd_n=1,
-            radius_cap_pd=.2, radius_cap_pd_n=1,
-            length_pd=.2, length_pd_n=10,
-            theta_pd=15, theta_pd_n=45,
-            phi_pd=15, phi_pd_n=1)
 q = 0.1
 # 2017-04-06: rkh add unit tests, NOT compared with any other calc method, assume correct!
 # 2019-05-17: pak added barbell/capped cylinder to realspace sampling tests

--- a/sasmodels/models/core_multi_shell.py
+++ b/sasmodels/models/core_multi_shell.py
@@ -146,15 +146,3 @@ def profile(sld_core, radius, sld_solvent, n, sld, thickness):
     rho.append(sld_solvent)
 
     return np.asarray(z), np.asarray(rho)
-
-demo = dict(sld_core=6.4,
-            radius=60,
-            sld_solvent=6.4,
-            n=2,
-            sld=[2.0, 3.0],
-            thickness=20,
-            thickness1_pd=0.3,
-            thickness2_pd=0.3,
-            thickness1_pd_n=10,
-            thickness2_pd_n=10,
-           )

--- a/sasmodels/models/core_shell_bicelle.py
+++ b/sasmodels/models/core_shell_bicelle.py
@@ -170,17 +170,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            radius=20.0,
-            thick_rim=10.0,
-            thick_face=10.0,
-            length=400.0,
-            sld_core=1.0,
-            sld_face=4.0,
-            sld_rim=4.0,
-            sld_solvent=1.0,
-            theta=90,
-            phi=0)
 q = 0.1
 # april 6 2017, rkh add unit tests, NOT compared with any other calc method, assume correct!
 qx = q*cos(pi/6.0)

--- a/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
+++ b/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
@@ -168,21 +168,6 @@ radius_effective_modes = [
 
 # TODO: No random() for core-shell bicelle elliptical belt rough
 
-demo = dict(scale=1, background=0,
-            radius=30.0,
-            x_core=3.0,
-            thick_rim=8.0,
-            thick_face=14.0,
-            length=50.0,
-            sld_core=4.0,
-            sld_face=7.0,
-            sld_rim=1.0,
-            sld_solvent=6.0,
-            theta=90,
-            phi=0,
-            psi=0,
-            sigma=0)
-
 q = 0.1
 # april 6 2017, rkh added a 2d unit test, NOT READY YET pull #890 branch assume correct!
 qx = q*cos(pi/6.0)

--- a/sasmodels/models/core_shell_cylinder.py
+++ b/sasmodels/models/core_shell_cylinder.py
@@ -155,15 +155,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            sld_core=6, sld_shell=8, sld_solvent=1,
-            radius=45, thickness=25, length=340,
-            theta=30, phi=15,
-            radius_pd=.2, radius_pd_n=1,
-            length_pd=.2, length_pd_n=10,
-            thickness_pd=.2, thickness_pd_n=10,
-            theta_pd=15, theta_pd_n=45,
-            phi_pd=15, phi_pd_n=1)
 q = 0.1
 # april 6 2017, rkh add unit tests, NOT compared with any other calc method, assume correct!
 qx = q*cos(pi/6.0)

--- a/sasmodels/models/core_shell_parallelepiped.py
+++ b/sasmodels/models/core_shell_parallelepiped.py
@@ -249,22 +249,6 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1, background=0.0,
-            sld_core=1, sld_a=2, sld_b=4, sld_c=2, sld_solvent=6,
-            length_a=35, length_b=75, length_c=400,
-            thick_rim_a=10, thick_rim_b=10, thick_rim_c=10,
-            theta=0, phi=0, psi=0,
-            length_a_pd=0.1, length_a_pd_n=1,
-            length_b_pd=0.1, length_b_pd_n=1,
-            length_c_pd=0.1, length_c_pd_n=1,
-            thick_rim_a_pd=0.1, thick_rim_a_pd_n=1,
-            thick_rim_b_pd=0.1, thick_rim_b_pd_n=1,
-            thick_rim_c_pd=0.1, thick_rim_c_pd_n=1,
-            theta_pd=10, theta_pd_n=1,
-            phi_pd=10, phi_pd_n=1,
-            psi_pd=10, psi_pd_n=1)
-
 # rkh 7/4/17 add random unit test for 2d, note make all params different,
 # 2d values not tested against other codes or models
 if 0:  # pak: model rewrite; need to update tests

--- a/sasmodels/models/core_shell_sphere.py
+++ b/sasmodels/models/core_shell_sphere.py
@@ -85,9 +85,6 @@ source = ["lib/sas_3j1x_x.c", "lib/core_shell.c", "core_shell_sphere.c"]
 have_Fq = True
 radius_effective_modes = ["outer radius", "core radius"]
 
-demo = dict(scale=1, background=0, radius=60, thickness=10,
-            sld_core=1.0, sld_shell=2.0, sld_solvent=0.0)
-
 def random():
     """Return a random parameter set for the model."""
     outer_radius = 10**np.random.uniform(1.3, 4.3)

--- a/sasmodels/models/correlation_length.py
+++ b/sasmodels/models/correlation_length.py
@@ -69,11 +69,6 @@ def Iq(q, lorentz_scale, porod_scale, cor_length, porod_exp, lorentz_exp):
     return inten
 Iq.vectorized = True
 
-# parameters for demo
-demo = dict(lorentz_scale=10.0, porod_scale=1.0e-06, cor_length=50.0,
-            porod_exp=3.0, lorentz_exp=2.0, background=0.1,
-           )
-
 tests = [[{}, 0.001, 1009.98],
          [{}, 0.150141, 0.175645],
          [{}, 0.442528, 0.0213957]]

--- a/sasmodels/models/cylinder.py
+++ b/sasmodels/models/cylinder.py
@@ -166,16 +166,6 @@ def random():
     return pars
 
 
-# parameters for demo
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            radius=20, length=300,
-            theta=60, phi=60,
-            radius_pd=.2, radius_pd_n=9,
-            length_pd=.2, length_pd_n=10,
-            theta_pd=10, theta_pd_n=5,
-            phi_pd=10, phi_pd_n=5)
-
 # Test 1-D and 2-D models
 qx, qy = 0.2 * np.cos(2.5), 0.2 * np.sin(2.5)
 theta, phi = 80.1534480601659, 10.1510817110481  # (10, 10) in sasview 3.x

--- a/sasmodels/models/dab.py
+++ b/sasmodels/models/dab.py
@@ -81,5 +81,3 @@ def random():
     )
     pars['scale'] /= pars['cor_length']**3
     return pars
-
-demo = dict(scale=1, background=0, cor_length=50)

--- a/sasmodels/models/ellipsoid.py
+++ b/sasmodels/models/ellipsoid.py
@@ -174,14 +174,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            radius_polar=50, radius_equatorial=30,
-            theta=30, phi=15,
-            radius_polar_pd=.2, radius_polar_pd_n=15,
-            radius_equatorial_pd=.2, radius_equatorial_pd_n=15,
-            theta_pd=15, theta_pd_n=45,
-            phi_pd=15, phi_pd_n=1)
 q = 0.1
 # april 6 2017, rkh add unit tests, NOT compared with any other calc method, assume correct!
 qx = q*cos(pi/6.0)

--- a/sasmodels/models/elliptical_cylinder.py
+++ b/sasmodels/models/elliptical_cylinder.py
@@ -129,10 +129,6 @@ radius_effective_modes = [
     "half length", "half min dimension", "half max dimension", "half diagonal",
     ]
 
-demo = dict(scale=1, background=0, radius_minor=100, axis_ratio=1.5, length=400.0,
-            sld=4.0, sld_solvent=1.0, theta=10.0, phi=20, psi=30,
-            theta_pd=10, phi_pd=2, psi_pd=3)
-
 def random():
     """Return a random parameter set for the model."""
     # V = pi * radius_major * radius_minor * length;

--- a/sasmodels/models/fractal.py
+++ b/sasmodels/models/fractal.py
@@ -118,13 +118,6 @@ def random():
     )
     return pars
 
-demo = dict(volfraction=0.05,
-            radius=5.0,
-            fractal_dim=2.0,
-            cor_length=100.0,
-            sld_block=2.0,
-            sld_solvent=6.4)
-
 # NOTE: test results taken from values returned by SasView 3.1.2
 tests = [
     [{}, 0.0005, 40.4980069872],

--- a/sasmodels/models/fractal_core_shell.py
+++ b/sasmodels/models/fractal_core_shell.py
@@ -115,17 +115,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=0.05,
-            background=0,
-            radius=20,
-            thickness=5,
-            sld_core=3.5,
-            sld_shell=1.0,
-            sld_solvent=6.35,
-            volfraction=0.05,
-            fractal_dim=2.0,
-            cor_length=100.0)
-
 # TODO: why is there an ER function here?
 def ER(radius, thickness):
     """

--- a/sasmodels/models/fuzzy_sphere.py
+++ b/sasmodels/models/fuzzy_sphere.py
@@ -101,13 +101,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0.001,
-            sld=1, sld_solvent=3,
-            radius=60,
-            fuzziness=10,
-            radius_pd=.2, radius_pd_n=45,
-            fuzziness_pd=.2, fuzziness_pd_n=0)
-
 tests = [
     # Accuracy tests based on content in test/utest_models_new1_3.py
     #[{'background': 0.001}, 1.0, 0.001],

--- a/sasmodels/models/gauss_lorentz_gel.py
+++ b/sasmodels/models/gauss_lorentz_gel.py
@@ -110,12 +110,6 @@ def random():
     return pars
 
 
-demo = dict(scale=1, background=0.1,
-            gauss_scale=100.0,
-            cor_length_static=100.0,
-            lorentz_scale=50.0,
-            cor_length_dynamic=20.0)
-
 tests = [
 
     # Accuracy tests based on content in test/utest_extra_models.py

--- a/sasmodels/models/gel_fit.py
+++ b/sasmodels/models/gel_fit.py
@@ -93,13 +93,6 @@ def random():
     )
     return pars
 
-demo = dict(background=0.01,
-            guinier_scale=1.7,
-            lorentz_scale=3.5,
-            rg=104,
-            fractal_dim=2.0,
-            cor_length=16.0)
-
 tests = [[{'guinier_scale': 1.0,
            'lorentz_scale': 1.0,
            'rg': 10.0,

--- a/sasmodels/models/guinier.py
+++ b/sasmodels/models/guinier.py
@@ -94,8 +94,5 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1.0, background=0.001, rg=60.0)
-
 # parameters for unit tests
 tests = [[{'rg' : 31.5}, 0.005, 0.992756]]

--- a/sasmodels/models/guinier_porod.py
+++ b/sasmodels/models/guinier_porod.py
@@ -132,6 +132,4 @@ def random():
     )
     return pars
 
-demo = dict(scale=1.5, background=0.5, rg=60, s=1.0, porod_exp=3.0)
-
 tests = [[{'scale': 1.5, 'background':0.5}, 0.04, 5.290096890253155]]

--- a/sasmodels/models/hayter_msa.py
+++ b/sasmodels/models/hayter_msa.py
@@ -112,6 +112,7 @@ parameters = [
     ["volfraction",   "None",     0.0192, [0, 0.74],   "", "volume fraction of spheres"],
     ["charge",        "e",   19.0,    [0.000001, 200],    "", "charge on sphere (in electrons)"],
     ["temperature",   "K",  318.16,   [0, 450],    "", "temperature, in Kelvin, for Debye length calculation"],
+    # TODO: demo parameters had concentration_salt=0.05
     ["concentration_salt",      "M",    0.0,    [0, inf], "", "conc of salt, moles/litre, 1:1 electolyte, for Debye length"],
     ["dielectconst",  "None",    71.08,   [-inf, inf], "", "dielectric constant (relative permittivity) of solvent, kappa, default water, for Debye length"]
     ]
@@ -142,22 +143,16 @@ def random():
     )
     return pars
 
-# default parameter set,  use  compare.sh -midQ -linear
-# note the calculation varies in different limiting cases so a wide range of
+# To run the demo use
+#   sascomp -midQ -linear conentration_salt=0.05 radius_effective_pd=0.1 \
+#       radius_effective_pd_n=40
+# Note the calculation varies in different limiting cases so a wide range of
 # parameters will be required for a thorough test!
-# odd that the default st has concentration_salt zero
-demo = dict(radius_effective=20.75,
-            charge=19.0,
-            volfraction=0.0192,
-            temperature=318.16,
-            concentration_salt=0.05,
-            dielectconst=71.08,
-            radius_effective_pd=0.1,
-            radius_effective_pd_n=40)
+# Odd that the default st has concentration_salt zero
 #
-# attempt to use same values as old sasview unit test at Q=.001 was 0.0712928,
+# Attempt to use same values as old sasview unit test at Q=.001 was 0.0712928,
 # then add lots new ones assuming values from new model are OK, need some
-# low Q values to test the small Q Taylor expansion
+# low Q values to test the small Q Taylor expansion.
 tests = [
     [{'scale': 1.0,
       'background': 0.0,

--- a/sasmodels/models/hollow_cylinder.py
+++ b/sasmodels/models/hollow_cylinder.py
@@ -123,15 +123,8 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1.0, background=0.0, length=400.0, radius=20.0,
-            thickness=10, sld=6.3, sld_solvent=1, theta=90, phi=0,
-            thickness_pd=0.2, thickness_pd_n=9,
-            length_pd=.2, length_pd_n=10,
-            radius_pd=.2, radius_pd_n=9,
-            theta_pd=10, theta_pd_n=5,
-           )
-
+# Tests for structure factor support functions. These functions duplicate
+# the equivalent functions from the C code for the hollow cylinder model.
 def r_eff(radius, thickness, length):
     """R_eff from excluded volume"""
     radius += thickness

--- a/sasmodels/models/hollow_rectangular_prism.py
+++ b/sasmodels/models/hollow_rectangular_prism.py
@@ -174,15 +174,6 @@ def random():
     )
     return pars
 
-
-# parameters for demo
-demo = dict(scale=1, background=0,
-            sld=6.3, sld_solvent=1.0,
-            length_a=35, b2a_ratio=1, c2a_ratio=1, thickness=1,
-            length_a_pd=0.1, length_a_pd_n=10,
-            b2a_ratio_pd=0.1, b2a_ratio_pd_n=1,
-            c2a_ratio_pd=0.1, c2a_ratio_pd_n=1)
-
 tests = [[{}, 0.2, 0.76687283098],
          [{}, [0.2], [0.76687283098]],
         ]

--- a/sasmodels/models/hollow_rectangular_prism_thin_walls.py
+++ b/sasmodels/models/hollow_rectangular_prism_thin_walls.py
@@ -129,15 +129,6 @@ def random():
     )
     return pars
 
-
-# parameters for demo
-demo = dict(scale=1, background=0,
-            sld=6.3, sld_solvent=1.0,
-            length_a=35, b2a_ratio=1, c2a_ratio=1,
-            length_a_pd=0.1, length_a_pd_n=10,
-            b2a_ratio_pd=0.1, b2a_ratio_pd_n=1,
-            c2a_ratio_pd=0.1, c2a_ratio_pd_n=1)
-
 tests = [[{}, 0.2, 0.837719188592],
          [{}, [0.2], [0.837719188592]],
         ]

--- a/sasmodels/models/lamellar.py
+++ b/sasmodels/models/lamellar.py
@@ -101,10 +101,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            thickness=40,
-            thickness_pd=0.2, thickness_pd_n=40)
 #  [(qx1, qy1), (qx2, qy2), ...], [I(qx1,qy1), I(qx2,qy2), ...]],
 tests = [
     [{'scale': 1.0, 'background': 0.0, 'thickness': 50.0,

--- a/sasmodels/models/lamellar_hg.py
+++ b/sasmodels/models/lamellar_hg.py
@@ -114,12 +114,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            length_tail=15, length_head=10,
-            sld=0.4, sld_head=3.0, sld_solvent=6.0,
-            length_tail_pd=0.2, length_tail_pd_n=40,
-            length_head_pd=0.01, length_head_pd_n=40)
-
 #
 tests = [
     [{'scale': 1.0, 'background': 0.0, 'length_tail': 15.0, 'length_head': 10.0,

--- a/sasmodels/models/lamellar_hg_stack_caille.py
+++ b/sasmodels/models/lamellar_hg_stack_caille.py
@@ -145,17 +145,6 @@ def random():
     )
     return pars
 
-demo = dict(
-    scale=1, background=0,
-    Nlayers=20, d_spacing=200., Caille_parameter=0.05,
-    length_tail=15, length_head=10,
-    #sld=-1, sld_head=4.0, sld_solvent=6.0,
-    sld=-1, sld_head=4.1, sld_solvent=6.0,
-    length_tail_pd=0.1, length_tail_pd_n=20,
-    length_head_pd=0.05, length_head_pd_n=30,
-    d_spacing_pd=0.2, d_spacing_pd_n=40,
-    )
-
 #
 tests = [[{'scale': 1.0, 'background': 0.0, 'length_tail': 10.0, 'length_head': 2.0,
            'Nlayers': 30.0, 'd_spacing': 40., 'Caille_parameter': 0.001, 'sld': 0.4,

--- a/sasmodels/models/lamellar_stack_caille.py
+++ b/sasmodels/models/lamellar_stack_caille.py
@@ -127,12 +127,6 @@ form_volume = """
     return 1.0;
     """
 
-demo = dict(scale=1, background=0,
-            thickness=67., Nlayers=3.75, d_spacing=200.,
-            Caille_parameter=0.268, sld=1.0, sld_solvent=6.34,
-            thickness_pd=0.1, thickness_pd_n=100,
-            d_spacing_pd=0.05, d_spacing_pd_n=40)
-
 #
 tests = [
     [{'scale': 1.0, 'background': 0.0, 'thickness': 30., 'Nlayers': 20.0,

--- a/sasmodels/models/lamellar_stack_paracrystal.py
+++ b/sasmodels/models/lamellar_stack_paracrystal.py
@@ -152,11 +152,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            thickness=33, Nlayers=20, d_spacing=250, sigma_d=0.2,
-            sld=1.0, sld_solvent=6.34,
-            thickness_pd=0.2, thickness_pd_n=40)
-
 #
 tests = [
     [{'scale': 1.0, 'background': 0.0, 'thickness': 33., 'Nlayers': 20.0,

--- a/sasmodels/models/lorentz.py
+++ b/sasmodels/models/lorentz.py
@@ -63,8 +63,5 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1.0, background=0.0, cor_length=50.0)
-
 # parameters for unit tests
 tests = [[{'cor_length': 250}, 0.01, 0.138931]]

--- a/sasmodels/models/mass_fractal.py
+++ b/sasmodels/models/mass_fractal.py
@@ -109,11 +109,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0,
-            radius=10.0,
-            fractal_dim_mass=1.9,
-            cutoff_length=100.0)
-
 tests = [
 
     # Accuracy tests based on content in test/utest_other_models.py

--- a/sasmodels/models/mass_surface_fractal.py
+++ b/sasmodels/models/mass_surface_fractal.py
@@ -116,12 +116,6 @@ def random():
     return pars
 
 
-demo = dict(scale=1, background=0,
-            fractal_dim_mass=1.8,
-            fractal_dim_surf=2.3,
-            rg_cluster=4000.0,
-            rg_primary=86.7)
-
 tests = [
 
     # Accuracy tests based on content in test/utest_other_models.py  All

--- a/sasmodels/models/mono_gauss_coil.py
+++ b/sasmodels/models/mono_gauss_coil.py
@@ -92,8 +92,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1.0, i_zero=70.0, rg=75.0, background=0.0)
-
 # these unit test values taken from SasView 3.1.2
 tests = [
     [{'scale': 1.0, 'i_zero': 70.0, 'rg': 75.0, 'background': 0.0},

--- a/sasmodels/models/onion.py
+++ b/sasmodels/models/onion.py
@@ -370,9 +370,11 @@ def profile(sld_core, radius_core, sld_solvent, n_shells,
             rho.append(sld_in[k])
         else:
             # exponential shell
-            # num_steps must be at least 1, so use floor()+1 rather than ceil
-            # to protect against a thickness0.
-            num_steps = np.floor(thickness[k]/dz) + 1
+            # num_steps in the profile must be at least 1, so use 1+truncation
+            # to guess the number of bins rather than rounding or ceiling,
+            # even when the layer has zero thickness.  Also, num_steps must
+            # be an integer rather than a float for the linspace function.
+            num_steps = int(thickness[k]/dz) + 1
             slope = (sld_out[k] - sld_in[k]) / expm1(A[k])
             const = (sld_in[k] - slope)
             for z_shell in np.linspace(0, thickness[k], num_steps+1):

--- a/sasmodels/models/onion.py
+++ b/sasmodels/models/onion.py
@@ -389,6 +389,9 @@ def profile(sld_core, radius_core, sld_solvent, n_shells,
 
 # TODO: no random parameter function for onion model
 
+# One of the few cases where demo values are useful because the default
+# model is really boring. Leave these here for now even though they are
+# never used.
 demo = {
     "sld_solvent": 2.2,
     "sld_core": 1.0,

--- a/sasmodels/models/parallelepiped.py
+++ b/sasmodels/models/parallelepiped.py
@@ -249,18 +249,6 @@ def random():
     )
     return pars
 
-
-# parameters for demo
-demo = dict(scale=1, background=0,
-            sld=6.3, sld_solvent=1.0,
-            length_a=35, length_b=75, length_c=400,
-            theta=45, phi=30, psi=15,
-            length_a_pd=0.1, length_a_pd_n=10,
-            length_b_pd=0.1, length_b_pd_n=1,
-            length_c_pd=0.1, length_c_pd_n=1,
-            theta_pd=10, theta_pd_n=1,
-            phi_pd=10, phi_pd_n=1,
-            psi_pd=10, psi_pd_n=10)
 # rkh 7/4/17 add random unit test for 2d, note make all params different,
 # 2d values not tested against other codes or models
 qx, qy = 0.2 * np.cos(np.pi/6.), 0.2 * np.sin(np.pi/6.)

--- a/sasmodels/models/peak_lorentz.py
+++ b/sasmodels/models/peak_lorentz.py
@@ -77,7 +77,4 @@ def random():
     )
     return pars
 
-demo = dict(scale=100, background=1.0,
-            peak_pos=0.05, peak_hwhm=0.005)
-
 tests = [[{'scale':100.0, 'background':1.0}, 0.001, 2.0305]]

--- a/sasmodels/models/pearl_necklace.py
+++ b/sasmodels/models/pearl_necklace.py
@@ -119,15 +119,6 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1, background=0, radius=80.0, edge_sep=350.0,
-            num_pearls=3, sld=1, sld_solvent=6.3, sld_string=1,
-            thick_string=2.5,
-            radius_pd=.2, radius_pd_n=5,
-            edge_sep_pd=25.0, edge_sep_pd_n=5,
-            num_pearls_pd=0, num_pearls_pd_n=0,
-            thick_string_pd=0.2, thick_string_pd_n=5,
-           )
 # ER function is not being used here, not that it is likely very sensible to
 # include an S(Q) with this model, the default in sasview 5.0 would be to the
 # "unconstrained" radius_effective.

--- a/sasmodels/models/poly_gauss_coil.py
+++ b/sasmodels/models/poly_gauss_coil.py
@@ -118,12 +118,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1.0,
-            i_zero=70.0,
-            rg=75.0,
-            polydispersity=2.0,
-            background=0.0)
-
 # these unit test values taken from SasView 3.1.2
 tests = [
     [{'scale': 1.0, 'i_zero': 70.0, 'rg': 75.0,

--- a/sasmodels/models/porod.py
+++ b/sasmodels/models/porod.py
@@ -61,8 +61,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1.5, background=0.5)
-
 tests = [
     [{'scale': 0.00001, 'background':0.01}, 0.04, 3.916250],
     [{}, 0.0, inf],

--- a/sasmodels/models/power_law.py
+++ b/sasmodels/models/power_law.py
@@ -66,8 +66,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1.0, power=4.0, background=0.0)
-
 tests = [
     [{'scale': 1.0, 'power': 4.0, 'background' : 0.0},
      [0.0106939, 0.469418], [7.64644e+07, 20.5949]],

--- a/sasmodels/models/raspberry.py
+++ b/sasmodels/models/raspberry.py
@@ -174,13 +174,6 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1, background=0.001,
-            sld_lg=-0.4, sld_sm=3.5, sld_solvent=6.36,
-            volfraction_lg=0.05, volfraction_sm=0.005, surface_fraction=0.4,
-            radius_lg=5000, radius_sm=100, penetration=0.0,
-            radius_lg_pd=.2, radius_lg_pd_n=10)
-
 # TODO: update tests so the parameters correspond to SasView parameters
 # The model was re-parameterized so the results have changed.
 # NOTE: test results taken from values returned by SasView 3.1.2, with

--- a/sasmodels/models/rectangular_prism.py
+++ b/sasmodels/models/rectangular_prism.py
@@ -158,14 +158,6 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(scale=1, background=0,
-            sld=6.3, sld_solvent=1.0,
-            length_a=35, b2a_ratio=1, c2a_ratio=1,
-            length_a_pd=0.1, length_a_pd_n=10,
-            b2a_ratio_pd=0.1, b2a_ratio_pd_n=1,
-            c2a_ratio_pd=0.1, c2a_ratio_pd_n=1)
-
 tests = [[{}, 0.2, 0.375248406825],
          [{}, [0.2], [0.375248406825]],
         ]

--- a/sasmodels/models/spherical_sld.py
+++ b/sasmodels/models/spherical_sld.py
@@ -271,6 +271,7 @@ def profile(n_shells, sld_solvent, sld, thickness,
 
 # TODO: no random parameter generator for spherical SLD.
 
+# Another interesting demo case, again because the default function is boring.
 demo = {
     "n_shells": 5,
     "n_steps": 35.0,

--- a/sasmodels/models/spinodal.py
+++ b/sasmodels/models/spinodal.py
@@ -99,6 +99,3 @@ def random():
         q_0=10**np.random.uniform(-3, -1),
     )
     return pars
-
-demo = dict(scale=1, background=0,
-            gamma=1, q_0=0.1)

--- a/sasmodels/models/squarewell.py
+++ b/sasmodels/models/squarewell.py
@@ -155,8 +155,6 @@ def random():
     )
     return pars
 
-demo = dict(radius_effective=50, volfraction=0.04, welldepth=1.5,
-            wellwidth=1.2, radius_effective_pd=0, radius_effective_pd_n=0)
 #
 tests = [
     [{'scale': 1.0, 'background': 0.0, 'radius_effective': 50.0,

--- a/sasmodels/models/stacked_disks.py
+++ b/sasmodels/models/stacked_disks.py
@@ -166,18 +166,6 @@ def random():
     )
     return pars
 
-demo = dict(background=0.001,
-            scale=0.01,
-            thick_core=10.0,
-            thick_layer=10.0,
-            radius=15.0,
-            n_stacking=1,
-            sigma_d=0,
-            sld_core=4,
-            sld_layer=0.0,
-            sld_solvent=5.0,
-            theta=90,
-            phi=0)
 # After redefinition of spherical coordinates -
 # tests had in old coords theta=0, phi=0; new coords theta=90, phi=0
 q = 0.1

--- a/sasmodels/models/stickyhardsphere.py
+++ b/sasmodels/models/stickyhardsphere.py
@@ -202,8 +202,6 @@ Iq = """
     return(sq);
 """
 
-demo = dict(radius_effective=200, volfraction=0.2, perturb=0.05,
-            stickiness=0.2, radius_effective_pd=0.1, radius_effective_pd_n=40)
 #
 tests = [
     [{'scale': 1.0, 'background': 0.0, 'radius_effective': 50.0,

--- a/sasmodels/models/teubner_strey.py
+++ b/sasmodels/models/teubner_strey.py
@@ -119,7 +119,4 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0, volfraction_a=0.5,
-            sld_a=0.3, sld_b=6.3,
-            d=100.0, xi=30.0)
 tests = [[{}, 0.06, 41.5918888453]]

--- a/sasmodels/models/triaxial_ellipsoid.py
+++ b/sasmodels/models/triaxial_ellipsoid.py
@@ -173,18 +173,6 @@ def random():
     )
     return pars
 
-
-demo = dict(scale=1, background=0,
-            sld=6, sld_solvent=1,
-            theta=30, phi=15, psi=5,
-            radius_equat_minor=25, radius_equat_major=36, radius_polar=50,
-            radius_equat_minor_pd=0, radius_equat_minor_pd_n=1,
-            radius_equat_major_pd=0, radius_equat_major_pd_n=1,
-            radius_polar_pd=.2, radius_polar_pd_n=30,
-            theta_pd=15, theta_pd_n=45,
-            phi_pd=15, phi_pd_n=1,
-            psi_pd=15, psi_pd_n=1)
-
 q = 0.1
 # april 6 2017, rkh add unit tests
 #     NOT compared with any other calc method, assume correct!

--- a/sasmodels/models/two_lorentzian.py
+++ b/sasmodels/models/two_lorentzian.py
@@ -112,14 +112,6 @@ def random():
     return pars
 
 
-demo = dict(scale=1, background=0.1,
-            lorentz_scale_1=10,
-            lorentz_length_1=100.0,
-            lorentz_exp_1=3.0,
-            lorentz_scale_2=1,
-            lorentz_length_2=10,
-            lorentz_exp_2=2.0)
-
 tests = [
 
     # Accuracy tests based on content in test/utest_extra_models.py

--- a/sasmodels/models/two_power_law.py
+++ b/sasmodels/models/two_power_law.py
@@ -113,12 +113,6 @@ def random():
     )
     return pars
 
-demo = dict(scale=1, background=0.0,
-            coefficent_1=1.0,
-            crossover=0.04,
-            power_1=1.0,
-            power_2=4.0)
-
 tests = [
     # Accuracy tests based on content in test/utest_extra_models.py
     [{'coefficent_1':     1.0,

--- a/sasmodels/models/unified_power_Rg.py
+++ b/sasmodels/models/unified_power_Rg.py
@@ -142,6 +142,7 @@ def random():
     pars.update(("G%d"%(k+1), v) for k, v in enumerate(G))
     return pars
 
+# multi-shell models want demo parameters
 demo = dict(
     level=2,
     rg=[15.8, 21],

--- a/sasmodels/models/vesicle.py
+++ b/sasmodels/models/vesicle.py
@@ -115,13 +115,6 @@ def random():
     )
     return pars
 
-# parameters for demo
-demo = dict(sld=0.5, sld_solvent=6.36,
-            volfraction=0.05,
-            radius=100, thickness=30,
-            radius_pd=.2, radius_pd_n=10,
-            thickness_pd=.2, thickness_pd_n=10)
-
 # NOTE: test results taken from values returned by SasView 3.1.2, with
 # 0.001 added for a non-zero default background.
 tests = [[{}, 0.0005, 859.916526646],

--- a/sasmodels/multiscat.py
+++ b/sasmodels/multiscat.py
@@ -584,7 +584,6 @@ def parse_pars(model, opts):
     seed = np.random.randint(1000000) if opts.random and opts.seed < 0 else opts.seed
     compare_opts = {
         'info': (model.info, model.info),
-        'use_demo': False,
         'seed': seed,
         'mono': True,
         'magnetic': False,

--- a/sasmodels/weights.py
+++ b/sasmodels/weights.py
@@ -219,7 +219,7 @@ class BoltzmannDispersion(Dispersion):
 # dispersion name -> disperser lookup table.
 # Maintain order since this is used by sasview GUI to order the options in
 # the dispersion type combobox.
-MODELS = OrderedDict((d.type, d) for d in (
+DISTRIBUTIONS = OrderedDict((d.type, d) for d in (
     RectangleDispersion,
     UniformDispersion,
     ArrayDispersion,
@@ -228,6 +228,8 @@ MODELS = OrderedDict((d.type, d) for d in (
     SchulzDispersion,
     BoltzmannDispersion
 ))
+# CRUFT: deprecated old name
+MODELS = DISTRIBUTIONS
 
 SAS_WEIGHTS_PATH = "~/.sasview/weights"
 def load_weights(pattern=None):
@@ -248,7 +250,7 @@ def load_weights(pattern=None):
         try:
             #print("loading weights from", filename)
             module = load_custom_kernel_module(filename)
-            MODELS[module.Dispersion.type] = module.Dispersion
+            DISTRIBUTIONS[module.Dispersion.type] = module.Dispersion
         except Exception as exc:
             logging.error(traceback.format_exc(exc))
 
@@ -276,7 +278,7 @@ def get_weights(disperser, n, width, nsigmas, value, limits, relative):
     if disperser == "array":
         raise NotImplementedError("Don't handle arrays through get_weights;"
                                   " use values and weights directly")
-    cls = MODELS[disperser]
+    cls = DISTRIBUTIONS[disperser]
     obj = cls(n, width, nsigmas)
     v, w = obj.get_weights(value, limits[0], limits[1], relative)
     return v, w/np.sum(w)

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     install_requires=install_requires,
     extras_require={
-        'full': ['docutils', 'bumps', 'matplotlib'],
+        'full': ['docutils', 'bumps', 'matplotlib', 'columnize'],
         'server': ['bumps'],
         'OpenCL': ["pyopencl"],
         'CUDA': ["pycuda"],


### PR DESCRIPTION
* model doc generation speedup
    - provide an image cache for the model plots
    - allowing image generation in parallel.
    - delay loading of opencl/cuda so that the GPU initialization doesn't happen until you need it

* sascomp random model generation 
    - RNG sequence changed, so same seed may now produce a different set of model parameters
   - add 'maxdim' as command line parameter (should really follow from q-range of the data instead of being a command line parameter).
   -  polydispersity is preferentially on larger dimensions
   - swap polydispersity with parameters, for example to make sure bell radius is greater than bar radius
   - suppress pd/magnetism no longer inserts pd/magnetism if it wasn't there and is not suppressed, which means that random models with polydispersity occasionally includes monodisperse models.

* sascomp updates
    - add option to display models rather than displaying them on error
    - improve multi-column formatting on list of models
    - *columnize* package is a new optional dependency
    - code cleanup for model parameter generation

* fixes
    - opencl: better error messages if zero length q vector

* cleanup
    - remove *demo* parameters from all the models.
    - polydispersity: rename weights.MODELS to weights.DISTRIBUTIONS; once sasview uses the new name we can delete the old name from weights.


