### PR TITLE
Avoiding unclosed files by using pathlib.Path

### DIFF
--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -181,6 +181,9 @@ except ImportError:
     pass
 # pylint: enable=unused-import
 
+# BRP added to avoid open files:
+from pathlib import Path
+
 logger = logging.getLogger(__name__)
 
 # jitter projection to use in the kernel code.  See explore/jitter.py
@@ -929,7 +932,7 @@ def make_source(model_info):
     # Load templates and user code
     kernel_header = load_template('kernel_header.c')
     kernel_code = load_template('kernel_iq.c')
-    user_code = [(f, open(f).read()) for f in model_sources(model_info)]
+    user_code = [(f, Path(f).read_text()) for f in model_sources(model_info)]
 
     # Build initial sources
     source = []

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+# BRP added to avoid open files:
+from pathlib import Path
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
@@ -38,7 +40,7 @@ setup(
     name='sasmodels',
     version=find_version('sasmodels'),
     description="sasmodels package",
-    long_description=open('README.rst').read(),
+    long_description=Path('README.rst').read_text(),
     author="SasView Collaboration",
     author_email="management@sasview.org",
     url="http://www.sasview.org",


### PR DESCRIPTION
Note: Solution may be restricted to Python 3.

Solution implemented to avoid the following open file warnings when using sasmodels:
-->
Exception ignored in: <_io.FileIO name='/Users/brian/Code/sasmodels/sasmodels/models/sphere.c' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/brian/Code/sasmodels/sasmodels/models/sphere.c' mode='r' encoding='UTF-8'>
Exception ignored in: <_io.FileIO name='/Users/brian/Code/sasmodels/sasmodels/models/lib/sas_3j1x_x.c' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/brian/Code/sasmodels/sasmodels/models/lib/sas_3j1x_x.c' mode='r' encoding='UTF-8'>
<--

Solution resolves issue. 