### PR TITLE
Fix pd for python models. Refs #399.

### DIFF
--- a/sasmodels/kernelpy.py
+++ b/sasmodels/kernelpy.py
@@ -280,9 +280,9 @@ def _loops(parameters,    # type: np.ndarray
                 # Update value and norm.
                 total += weight * Iq
                 weight_norm += weight
-                shell, form = form_volume()
-                weighted_form += weight * form
-                weighted_shell += weight * shell
+                unweighted_shell, unweighted_form = form_volume()
+                weighted_shell += weight * unweighted_shell
+                weighted_form += weight * unweighted_form
                 weighted_radius += weight * form_radius()
 
     result = np.hstack((total, weight_norm, weighted_form, weighted_shell, weighted_radius))

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -940,11 +940,23 @@ def make_model_info(kernel_module):
     info.source = getattr(kernel_module, 'source', [])
     info.c_code = getattr(kernel_module, 'c_code', None)
     info.radius_effective = getattr(kernel_module, 'radius_effective', None)
+    # CRUFT: support old-style ER() for effective radius
+    if info.radius_effective is None:
+        ER = getattr(kernel_module, 'ER', None)
+        if ER is not None:
+            info.radius_effective_modes = ['ER']
+            info.radius_effective = lambda mode, *args: ER(*args)
     # TODO: check the structure of the tests
     info.tests = getattr(kernel_module, 'tests', [])
     info.valid = getattr(kernel_module, 'valid', '')
     info.form_volume = getattr(kernel_module, 'form_volume', None) # type: ignore
     info.shell_volume = getattr(kernel_module, 'shell_volume', None) # type: ignore
+    ## --- untested, so left unsupported for now ---
+    ## CRUFT: support old-style VR for form/shell ratio
+    #if info.shell_volume is None:
+    #    VR = getattr(kernel_module, 'VR')
+    #    if VR is not None:
+    #        info.shell_volume = lambda *args: info.form_volume(*args)*VR(*args)
     info.Iq = getattr(kernel_module, 'Iq', None) # type: ignore
     info.Iqxy = getattr(kernel_module, 'Iqxy', None) # type: ignore
     info.Iqac = getattr(kernel_module, 'Iqac', None) # type: ignore

--- a/sasmodels/models/fractal_core_shell.py
+++ b/sasmodels/models/fractal_core_shell.py
@@ -115,15 +115,6 @@ def random():
     )
     return pars
 
-# TODO: why is there an ER function here?
-def ER(radius, thickness):
-    """
-        Equivalent radius
-        @param radius: core radius
-        @param thickness: shell thickness
-    """
-    return radius + thickness
-
 #tests = [[{'radius': 20.0, 'thickness': 10.0}, 'ER', 30.0],
 tests = [
     # At some point the SasView 3.x test result was deemed incorrect.  The


### PR DESCRIPTION
Fixes #399.  

Also restores support for single effective radius via ER() function with no mode parameter so models can work in both 4.2 and 5.0