### PR TITLE
sasview 1534: use source hash as part of dll name to avoid collisions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,33 @@
+Release notes
+=============
+
+v1.0.3 2020-05-??
+------------------
+* fix dll cache so multiple versions can coexist
+* fix polydispersity for python models
+* warn if ER function is present in model but not used
+
+v1.0.2 2020-04-14
+-----------------
+* doc updates: Porod
+* doc updates: change "Source intensity" to "Scale factor or Volume fraction"
+* doc updates: fix latex errors
+* change MODELS to DISTRIBUTIONS in sasmodels.weights
+* close open handles when done reading files
+* support latest numpy
+* improve model tests
+* faster generation of model docs
+* support compiler flags coming from environment (for .deb packaging)
+* build docs as part of continuous integration test suite
+
+v1.0.1 2019-10-03
+-----------------
+* reparameterize models to preserve constraints within polydisperse systems
+* doc update: fix units on lorentzian exponent
+* barbell: use consistent equations in docs, code and references
+* validation: check triaxial ellipsoid, barbell against MC calculation
+
+
+v1.0.0 2019-05-20
+-----------------
+see git log for details

--- a/sasmodels/kerneldll.py
+++ b/sasmodels/kerneldll.py
@@ -256,25 +256,17 @@ def make_dll(source, model_info, dtype=F64):
         dtype = F64  # Force 64-bit dll.
     # Note: dtype may be F128 for long double precision.
 
-    # TOOD: Tag each dll with the hash of the source to avoid collisions.
     # TODO: Deal with ever-growing ~/.sasmodels/compiled_models.
     # TODO: Is the GPU model cache growing without bound?
-    if model_info.filename is None:
-        model_file = model_info.id + "_" + generate.tag_source(source)
-    else:
-        # Don't need to tag models which have an associated file since the
-        # timestamps on the dependencies will let us know they need to be
-        # regenerated.
-        model_file = model_info.id
+    # Tag model name with hash so any change to the model or the wrapper
+    # will generate a new dll. Need to tag with dtype as well because
+    # double has not yet been converted to the target type in the source.
+    # Don't use time stamps for caching since they are not reliable, especially
+    # when multiple versions of the application are installed.
+    model_file = model_info.id + "_" + generate.tag_source(source)
     dll = dll_path(model_file, dtype)
 
     if not os.path.exists(dll):
-        need_recompile = True
-    else:
-        dll_time = os.path.getmtime(dll)
-        newest_source = generate.dll_timestamp(model_info)
-        need_recompile = dll_time < newest_source
-    if need_recompile:
         # Make sure the DLL path exists.
         if not os.path.exists(SAS_DLL_PATH):
             os.makedirs(SAS_DLL_PATH)


### PR DESCRIPTION
See https://github.com/SasView/sasview/issues/1534

Different versions of sasview on the same machine will end up using the same dll files, causing crashes and unexpected results.