### PR TITLE
use forward slash in c preprocessor file names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ matrix:
   include:
   - os: linux
     env:
-    - PY=2.7
-  - os: linux
-    env:
     - PY=3.6
   - os: linux
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ matrix:
   include:
   - os: linux
     env:
+    - PY=2.7
+  - os: linux
+    env:
     - PY=3.6
   - os: linux
     env:

--- a/sasmodels/generate.py
+++ b/sasmodels/generate.py
@@ -992,8 +992,8 @@ def make_source(model_info):
 
     # Validity check macro.  Putting it here so that line number
     # jiggering is short-lived.
-    source.append('#line %d "%s"'
-                  % (model_info.lineno.get('valid', 1), model_info.basefile))
+    _add_source(source, valid, model_info.basefile,
+                lineno=model_info.lineno.get('valid', 1))
     source.append(valid)
 
     # Define the parameter table


### PR DESCRIPTION
Windows users are getting errors such as the following when building models:
```
RuntimeError: clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE

Build on <pyopencl.Device 'Intel(R) UHD Graphics 620' on 'Intel(R) OpenCL' at 0x27007baf800>:

C:/Users.../sasmodels/models/sphere.c:22:12: error: \U used with no following hex digits
#line 1 "C:\Users\...\sasmodels\models\sphere.py"
           ^~
C:/Users/.../sasmodels/models/sphere.c:22:18: warning: unknown escape sequence '\s'
#line 1 "C:\Users\...\sasmodels\models\sphere.py"
                     ^~
C:/Users/.../sasmodels/models/sphere.c:22:24: warning: unknown escape sequence '\s'
#line 1 "C:\Users\...\sasmodels\models\sphere.py"
                                      ^~
```

In particular, the `\U` is expecting 32-bit unicode and causing the compiler to fail.

The following patch may fix this, but somebody on a failing windows box will need to try.