### PR TITLE
show name of model rather than test number in pytest results

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,9 @@ import inspect
 import pytest
 from _pytest.unittest import TestCaseFunction
 
+# CRUFT: pytest<5.4 does not have from_parent class method.
+function_test = getattr(pytest.Function, 'from_parent', pytest.Function)
+
 def pytest_pycollect_makeitem(collector, name, obj):
     """
     Convert test generator into list of function tests so that pytest doesn't
@@ -52,8 +55,8 @@ def pytest_pycollect_makeitem(collector, name, obj):
         for number, yielded in enumerate(obj()):
             index, call, args = split_yielded_test(yielded, number)
             description = getattr(call, 'description', name+index)
-            test = pytest.Function.from_parent(
-                collector, name=description, args=args, callobj=call)
+            test = function_test(
+                parent=collector, name=description, args=args, callobj=call)
             tests.append(test)
         return tests
 

--- a/conftest.py
+++ b/conftest.py
@@ -51,7 +51,9 @@ def pytest_pycollect_makeitem(collector, name, obj):
         tests = []
         for number, yielded in enumerate(obj()):
             index, call, args = split_yielded_test(yielded, number)
-            test = pytest.Function(name+index, collector, args=args, callobj=call)
+            description = getattr(call, 'description', name+index)
+            test = pytest.Function.from_parent(
+                collector, name=description, args=args, callobj=call)
             tests.append(test)
         return tests
 

--- a/sasmodels/model_test.py
+++ b/sasmodels/model_test.py
@@ -132,7 +132,7 @@ def _add_model_to_suite(loaders, suite, model_info):
     stash = []
 
     if is_py:  # kernel implemented in python
-        test_name = "%s-python"%model_info.name
+        test_name = "%s[python]"%model_info.name
         test_method_name = "test_%s_python" % model_info.id
         test = ModelTestCase(test_name, model_info,
                              test_method_name,
@@ -144,7 +144,7 @@ def _add_model_to_suite(loaders, suite, model_info):
 
         # test using dll if desired
         if 'dll' in loaders or not use_opencl():
-            test_name = "%s-dll"%model_info.name
+            test_name = "%s[dll]"%model_info.name
             test_method_name = "test_%s_dll" % model_info.id
             test = ModelTestCase(test_name, model_info,
                                  test_method_name,
@@ -155,7 +155,7 @@ def _add_model_to_suite(loaders, suite, model_info):
 
         # test using opencl if desired and available
         if 'opencl' in loaders and use_opencl():
-            test_name = "%s-opencl"%model_info.name
+            test_name = "%s[opencl]"%model_info.name
             test_method_name = "test_%s_opencl" % model_info.id
             # Using dtype=None so that the models that are only
             # correct for double precision are not tested using
@@ -170,7 +170,7 @@ def _add_model_to_suite(loaders, suite, model_info):
 
         # test using cuda if desired and available
         if 'cuda' in loaders and use_cuda():
-            test_name = "%s-cuda" % model_info.id
+            test_name = "%s[cuda]" % model_info.id
             test_method_name = "test_%s_cuda" % model_info.id
             # Using dtype=None so that the models that are only
             # correct for double precision are not tested using


### PR DESCRIPTION
Display output of pytest as
```
sasmodels/model_test.py::NAME[TYPE] STATUS
```
rather than
```
sasmodels/model_test.py::model_test[#] STATUS
```

Also fixes warning about deprecated behaviour in pytest 5.4.

Not tested with sasview.  The test name was changed from NAME-TYPE to NAME[TYPE], so the GPU discovery code may break if it is attempting to parse the test name.

