### PR TITLE
py27: use makedirs with backported interface for py27 doc builds

### DIFF
--- a/doc/genmodel.py
+++ b/doc/genmodel.py
@@ -442,7 +442,7 @@ def main():
     if not os.path.exists(TARGET_DIR) and not args.sphinx:
         print("build directory %r does not exist"%TARGET_DIR)
         sys.exit(1)
-    os.makedirs(TARGET_DIR, exist_ok=True)
+    makedirs(TARGET_DIR, exist_ok=True)
 
     if args.cpus == -1:
         cpus = int(os.environ.get("SASMODELS_BUILD_CPUS", "0"))


### PR DESCRIPTION
paper bag commit: let's test the doc build locally on py27 before creating the pull request!

I hope this is the last py27 error.