### PR TITLE
Suppress pyopencl caching bug for Intel on Mac. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,16 @@
 Release notes
 =============
 
-v1.0.3 2020-05-??
+v1.0.3 2020-07-??
 ------------------
-* fix dll cache so multiple versions can coexist
 * fix polydispersity for python models
-* warn if ER function is present in model but not used
+* fix dll cache so multiple versions can coexist
+* fix caching bug on pyopencl for Intel on OS/X
+* fix tinycc compilation bug on windows indicating bad backslash escape
+* warn if ER function is present in plugin model but not used
+* restore python 2.7 support
 
-v1.0.2 2020-04-14
+v1.0.2 2020-04-24
 -----------------
 * doc updates: Porod
 * doc updates: change "Source intensity" to "Scale factor or Volume fraction"

--- a/sasmodels/kernelcl.py
+++ b/sasmodels/kernelcl.py
@@ -74,6 +74,10 @@ try:
     import pyopencl as cl  # type: ignore
     from pyopencl import mem_flags as mf
     from pyopencl.characterize import get_fast_inaccurate_build_options
+    # CRUFT: pyopencl<2019.1.2 is breaking on intel drivers for mac
+    from pyopencl.version import VERSION_TEXT
+    if sys.platform == 'darwin' and VERSION_TEXT < '2019.1.2':
+        os.environ['PYOPENCL_NO_CACHE'] = '1'
     # Ask OpenCL for the default context so that we know that one exists.
     cl.create_some_context(interactive=False)
     HAVE_OPENCL = True


### PR DESCRIPTION
Addresses #365 for cases when the newer pyopencl package is not installed.