### PR TITLE
Add python model to the list of linked files. Ref sasview 1631.

### DIFF
--- a/doc/genmodel.py
+++ b/doc/genmodel.py
@@ -212,10 +212,8 @@ def link_sources(model_info):
     Add link to model sources from the doc tree.
     """
     # List source files in order of dependency.
-    if model_info.source:
-        sources = generate.model_sources(model_info)
-    else:
-        sources = [model_info.basefile]
+    sources = generate.model_sources(model_info) if model_info.source else []
+    sources.append(model_info.basefile)
 
     # Copy files to src dir under models directory.  Need to do this
     # because sphinx can't link to an absolute path.


### PR DESCRIPTION
Partial fix for https://github.com/SasView/sasview/issues/1631. The python file will now be included in the list of linked sources.

The broken link is probably in sasview, which is only copying the dependencies, not the model file.