### PR TITLE
Miscellaneous typo fixes in models

### DIFF
--- a/sasmodels/models/_spherepy.py
+++ b/sasmodels/models/_spherepy.py
@@ -85,7 +85,7 @@ def Iq(q, sld, sld_solvent, radius):
     #print "sld,r",sld,sld_solvent,radius
     qr = q * radius
     sn, cn = sin(qr), cos(qr)
-    ## The natural expression for the bessel function is the following:
+    ## The natural expression for the Bessel function is the following:
     ##     bes = 3 * (sn-qr*cn)/qr**3 if qr>0 else 1
     ## however, to support vector q values we need to handle the conditional
     ## as a vector, which we do by first evaluating the full expression

--- a/sasmodels/models/bcc_paracrystal.py
+++ b/sasmodels/models/bcc_paracrystal.py
@@ -141,7 +141,7 @@ source = ["lib/sas_3j1x_x.c", "lib/gauss150.c", "lib/sphere_form.c", "bcc_paracr
 def random():
     """Return a random parameter set for the model."""
     # Define lattice spacing as a multiple of the particle radius
-    # using the formulat a = 4 r/sqrt(3).  Systems which are ordered
+    # using the formula a = 4 r/sqrt(3).  Systems which are ordered
     # are probably mostly filled, so use a distribution which goes from
     # zero to one, but leaving 90% of them within 80% of the
     # maximum bcc packing.  Lattice distortion values are empirically

--- a/sasmodels/models/be_polyelectrolyte.py
+++ b/sasmodels/models/be_polyelectrolyte.py
@@ -144,7 +144,7 @@ def Iq(q,
 
     parameter names, units, default values, and behavior (volume, sld etc) are
     defined in the parameter table.  The concentrations are converted from
-    experimental mol/L to dimensionaly useful 1/A3 in first two lines
+    experimental mol/L to dimensionally useful 1/A3 in first two lines
     """
 
     concentration_pol = polymer_concentration * 6.022136e-4

--- a/sasmodels/models/core_shell_bicelle.py
+++ b/sasmodels/models/core_shell_bicelle.py
@@ -64,7 +64,7 @@ where
 where $V_t$ is the total volume of the bicelle, $V_c$ the volume of the core,
 $V_{c+f}$ the volume of the core plus the volume of the faces, $R$ is the radius
 of the core, $L$ the length of the core, $t_f$ the thickness of the face, $t_r$
-the thickness of the rim and $J_1$ the usual first order bessel function.
+the thickness of the rim and $J_1$ the usual first order Bessel function.
 
 The output of the 1D scattering intensity function for randomly oriented
 cylinders is then given by integrating over all possible $\theta$ and $\phi$.

--- a/sasmodels/models/core_shell_bicelle_elliptical.py
+++ b/sasmodels/models/core_shell_bicelle_elliptical.py
@@ -76,7 +76,7 @@ the bicelle, $V_c = \pi.Xcore.R^2.L$ the volume of the core,
 $V_{c+f} = \pi.Xcore.R^2.(L+2.t_f)$ the volume of the core plus the volume
 of the faces, $R$ is the radius of the core, $Xcore$ is the axial ratio of
 the core, $L$ the length of the core, $t_f$ the thickness of the face, $t_r$
-the thickness of the rim and $J_1$ the usual first order bessel function.
+the thickness of the rim and $J_1$ the usual first order Bessel function.
 The core has radii $R$ and $Xcore.R$ so is circular, as for the
 core_shell_bicelle model, for $Xcore$ =1. Note that you may need to
 limit the range of $Xcore$, especially if using the Monte-Carlo algorithm,

--- a/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
+++ b/sasmodels/models/core_shell_bicelle_elliptical_belt_rough.py
@@ -80,7 +80,7 @@ plus the volume of the faces, $V_{c+r} = \pi (R+t_r)(X_\text{core} R+t_r) L$
 the volume of the core plus the rim, $R$ is the radius of the core,
 $X_\text{core}$ is the axial ratio of the core, $L$ the length of the core,
 $t_f$ the thickness of the face, $t_r$ the thickness of the rim and $J_1$ the
-usual first order bessel function. The core has radii $R$ and $X_\text{core} R$
+usual first order Bessel function. The core has radii $R$ and $X_\text{core} R$
 so is circular, as for the core_shell_bicelle model, for $X_\text{core}=1$.
 Note that you may need to limit the range of $X_\text{core}$, especially if
 using the Monte-Carlo algorithm, as setting radius to $R/X_\text{core}$ and

--- a/sasmodels/models/core_shell_parallelepiped.py
+++ b/sasmodels/models/core_shell_parallelepiped.py
@@ -120,7 +120,7 @@ FITTING NOTES
 
 #. For 2d data the orientation of the particle is required, described using
    angles $\theta$, $\phi$ and $\Psi$ as in the diagrams below, where $\theta$
-   and $\phi$ define the orientation of the director in the laboratry reference
+   and $\phi$ define the orientation of the director in the laboratory reference
    frame of the beam direction ($z$) and detector plane ($x-y$ plane), while
    the angle $\Psi$ is effectively the rotational angle around the particle
    $C$ axis. For $\theta = 0$ and $\phi = 0$, $\Psi = 0$ corresponds to the
@@ -131,7 +131,7 @@ FITTING NOTES
    axis (in the $x-y$ plane). Applying orientational distribution to the
    particle orientation (i.e  `jitter` to one or more of these angles) can get
    more confusing as `jitter` is defined **NOT** with respect to the laboratory
-   frame but the particle reference frame. It is thus highly recmmended to
+   frame but the particle reference frame. It is thus highly recommended to
    read :ref:`orientation` for further details of the calculation and angular
    dispersions.
 

--- a/sasmodels/models/cylinder.py
+++ b/sasmodels/models/cylinder.py
@@ -124,7 +124,7 @@ description = """
             V: Volume of the cylinder
             R: Radius of the cylinder
             L: Length of the cylinder
-            J1: The bessel function
+            J1: The Bessel function
             alpha: angle between the axis of the
             cylinder and the q-vector for 1D
             :the ouput is P(q)=scale/V*integral

--- a/sasmodels/models/ellipsoid.py
+++ b/sasmodels/models/ellipsoid.py
@@ -99,7 +99,7 @@ to be stable over the range of $q$ shown for a number of points higher
 than 500.
 
 Model was also tested against the triaxial ellipsoid model with equal major
-and minor equatorial radii.  It is also consistent with the cyclinder model
+and minor equatorial radii.  It is also consistent with the cylinder model
 with polar radius equal to length and equatorial radius equal to radius.
 
 References
@@ -180,49 +180,49 @@ tests = [
     [{}, 0.05, 54.8525847025],
     [{'theta': 80., 'phi': 10.}, (qx, qy), 1.74134670026],
 
-    # Test beta and the effective radius with the equivelent sphere (May 15, 2019)
+    # Test beta and the effective radius with the equivalent sphere (May 15, 2019)
     # Yun's matlab report [0.006,0.05,0.1], [330.0, 10.976, 1.369]
-    # The values in the code here are calcualted results from SASVieww (May 15, 2019)
+    # The values in the code here are calculated results from SasView (May 15, 2019)
     [{"@S": "hardsphere",
       "scale": 1., "background": 0., "volfraction": 0.2,
       "structure_factor_mode": 1,  # beta approx
-      "radius_effective_mode": 2   # Reff "equivelent sphere"
+      "radius_effective_mode": 2   # Reff "equivalent sphere"
      },
      [0.006, 0.05, 0.1],
      [330.0082676127404, 10.96932155837644, 1.35347369429977]],
 
     # Test beta and the effective radius with the minor radius (May 15, 2019)
     # Yun's matlab report [0.006,0.05,0.1], [273.67, 10.942, 1.3683]
-    # The values in the code here are calcualted results from SASVieww (May 15, 2019)
+    # The values in the code here are calculated results from SasView (May 15, 2019)
     [{"@S": "hardsphere",
       "scale": 1., "background": 0., "volfraction": 0.2,
       "structure_factor_mode": 1,  # beta approx
-      "radius_effective_mode": 3   # Reff "equivelent sphere"
+      "radius_effective_mode": 3   # Reff "equivalent sphere"
      },
      [0.006, 0.05, 0.1],
      [273.64522316236287, 10.93682961898512, 1.352864896244188]],
 
     # Test beta and the effective radius with the major radius (May 15, 2019)
     # Yun's matlab report [0.006,0.05,0.1], [1062.37, 10.977, 1.369]
-    # The values in the code here are calcualted results from SASVieww (May 15, 2019)
+    # The values in the code here are calculated results from SasView (May 15, 2019)
     [{"@S": "hardsphere",
       "scale": 1., "background": 0., "volfraction": 0.2,
       "structure_factor_mode": 1,  # beta approx
-      "radius_effective_mode": 4   # Reff "equivelent sphere"
+      "radius_effective_mode": 4   # Reff "equivalent sphere"
      },
      [0.006, 0.05, 0.1],
      [1062.3690121068357, 10.970147034298845, 1.3534794742102454]],
 
     # Test beta and the effective radius with the average curvature (May 15, 2019)
-    # Effective radius is taken from the SASView calcuation.
-    # With defaul values, the effective radius is 270.745.
+    # Effective radius is taken from the SasView calculation.
+    # With default values, the effective radius is 270.745.
     # The calculated values using Yun's Matlab code are
     #     [0.006,0.05,0.1], [529.03,419.22, 10.977, 1.369]
-    # The values in the code here are calcualted results from SASVieww (May 15, 2019)
+    # The values in the code here are calculated results from SasView (May 15, 2019)
     [{"@S": "hardsphere",
       "scale": 1., "background": 0., "volfraction": 0.2,
       "structure_factor_mode": 1,  # beta approx
-      "radius_effective_mode": 1   # Reff "equivelent sphere"
+      "radius_effective_mode": 1   # Reff "equivalent sphere"
      },
      [0.006, 0.01, 0.05, 0.1],
      [529.0109355849872, 419.2280055002956, 10.970118278295908, 1.3534762023877278]]

--- a/sasmodels/models/fractal_core_shell.py
+++ b/sasmodels/models/fractal_core_shell.py
@@ -119,7 +119,7 @@ def random():
 tests = [
     # At some point the SasView 3.x test result was deemed incorrect.  The
     # following tests were verified against NIST IGOR macros ver 7.850.
-    # NOTE: NIST macros do only provide for a polydispers core (no option
+    # NOTE: NIST macros do only provide for a polydisperse core (no option
     # for a poly shell or for a monodisperse core.  The results seemed
     # extremely sensitive to the core PD, varying non monotonically all
     # the way to a PD of 1e-6. From 1e-6 to 1e-9 no changes in the

--- a/sasmodels/models/guinier.py
+++ b/sasmodels/models/guinier.py
@@ -9,7 +9,7 @@ This model fits the Guinier function
     I(q) = \text{scale} \cdot \exp{\left[ \frac{-Q^2 R_g^2 }{3} \right]}
             + \text{background}
 
-to the data directly without any need for linearisation (*cf*. the usual
+to the data directly without any need for linearization (*cf*. the usual
 plot of $\ln I(q)$ vs $q^2$\ ). Note that you may have to restrict the data
 range to include small q only, where the Guinier approximation actually
 applies. See also the guinier_porod model.
@@ -19,8 +19,8 @@ where the $q$ vector is defined as
 
 .. math:: q = \sqrt{q_x^2 + q_y^2}
 
-In scattering, the radius of gyration $R_g$ quantifies the objects's
-distribution of SLD (not mass density, as in mechanics) from the objects's
+In scattering, the radius of gyration $R_g$ quantifies the object's
+distribution of SLD (not mass density, as in mechanics) from the object's
 SLD centre of mass. It is defined by
 
 .. math:: R_g^2 = \frac{\sum_i\rho_i\left(r_i-r_0\right)^2}{\sum_i\rho_i}
@@ -82,7 +82,7 @@ Iq = """
 def random():
     """Return a random parameter set for the model."""
     scale = 10**np.random.uniform(1, 4)
-    # Note: compare.py has Rg cutoff of 1e-30 at q=1 for guinier, so use that
+    # Note: compare.py has Rg cutoff of 1e-30 at q=1 for Guinier, so use that
     # log_10 Ae^(-(q Rg)^2/3) = log_10(A) - (q Rg)^2/ (3 ln 10) > -30
     #   => log_10(A) > Rg^2/(3 ln 10) - 30
     q_max = 1.0

--- a/sasmodels/models/multilayer_vesicle.py
+++ b/sasmodels/models/multilayer_vesicle.py
@@ -48,10 +48,10 @@ USAGE NOTES
   calculations rather slow.
 * The number of shells is always rounded to an integer value as a non integer
   number of layers is not physical.
-* Thus Polydispersity should only be applied to number of shells **VERY
+* Thus polydispersity should only be applied to number of shells **VERY
   CAREFULLY**.  A possible legitimate use would be for mixed systems in which
   some vesicles have 1 shell, some have 2, etc. A polydispersity on $N$ can be
-  used to model the data by using the "array distriubtion" feature. First
+  used to model the data by using the "array distribution" feature. First
   create a file such as *shell_dist.txt* containing the relative portion
   of each vesicle size::
 
@@ -68,7 +68,7 @@ USAGE NOTES
   function complicated by the fact that the number of water/shell pairs must
   physically be an integer value, although the optimization treats it as a
   floating point value. Thus it may be that the resolution interpolation is not
-  sufficiently fine grained in certain cases. Please report any such occurences
+  sufficiently fine grained in certain cases. Please report any such occurrences
   to the SasView team. Generally, for the best possible experience:
 
  - Start with the best possible guess

--- a/sasmodels/models/onion.py
+++ b/sasmodels/models/onion.py
@@ -51,7 +51,7 @@ constant SLD within the core and solvent, so
         &= -3\rho_\text{solvent}V(r_N)\frac{j_1(q r_N)}{q r_N}
     \end{align*}
 
-where the spherical bessel function $j_1$ is
+where the spherical Bessel function $j_1$ is
 
 .. math::
 

--- a/sasmodels/models/parallelepiped.py
+++ b/sasmodels/models/parallelepiped.py
@@ -119,7 +119,7 @@ FITTING NOTES
 
 #. For 2d data the orientation of the particle is required, described using
    angles $\theta$, $\phi$ and $\Psi$ as in the diagrams below, where $\theta$
-   and $\phi$ define the orientation of the director in the laboratry reference
+   and $\phi$ define the orientation of the director in the laboratory reference
    frame of the beam direction ($z$) and detector plane ($x-y$ plane), while
    the angle $\Psi$ is effectively the rotational angle around the particle
    $C$ axis. For $\theta = 0$ and $\phi = 0$, $\Psi = 0$ corresponds to the
@@ -130,7 +130,7 @@ FITTING NOTES
    axis (in the $x-y$ plane). Applying orientational distribution to the
    particle orientation (i.e  `jitter` to one or more of these angles) can get
    more confusing as `jitter` is defined **NOT** with respect to the laboratory
-   frame but the particle reference frame. It is thus highly recmmended to
+   frame but the particle reference frame. It is thus highly recommended to
    read :ref:`orientation` for further details of the calculation and angular
    dispersions.
 
@@ -155,7 +155,7 @@ FITTING NOTES
    I am commenting this section out as we are trying to minimize the amount of
    oritentational detail here and encourage the user to go to the full
    orientation documentation so that changes can be made in just one place.
-   below is the commented paragrah:
+   below is the commented paragraph:
    On introducing "Orientational Distribution" in the angles, "distribution of
    theta" and "distribution of phi" parameters will appear. These are actually
    rotations about axes $\delta_1$ and $\delta_2$ of the parallelepiped,

--- a/sasmodels/models/peak_lorentz.py
+++ b/sasmodels/models/peak_lorentz.py
@@ -40,7 +40,7 @@ from numpy import inf
 name = "peak_lorentz"
 title = "A Lorentzian peak on a flat background"
 description = """\
-      Class that evaluates a lorentzian  shaped peak.
+      Class that evaluates a Lorentzian shaped peak.
 
         F(q) = scale/(1+[(q-q0)/B]^2 ) + background
 

--- a/sasmodels/models/polymer_micelle.py
+++ b/sasmodels/models/polymer_micelle.py
@@ -19,7 +19,7 @@ The Gaussian random coil tails, of gyration radius $R_g$, are imagined
 uniformly distributed around the spherical core, centred at a distance
 $r + d \cdot R_g$ from the micelle centre, where $d$ = *d_penetration* is
 of order unity. A volume $V_\text{corona}$ is defined for each coil. The
-model in detail seems to separately parametrise the terms for the shape
+model in detail seems to separately parameterize the terms for the shape
 of $I(Q)$ and the relative intensity of each term, so use with caution
 and check parameters for consistency. The spherical core is monodisperse,
 so it's intensity and the cross terms may have sharp oscillations (use $q$

--- a/sasmodels/models/porod.py
+++ b/sasmodels/models/porod.py
@@ -12,7 +12,7 @@ dilute particulate system regardless of shape or size but only to the very low
 $q$ (being a taylor expansion around $q$ = 0), the Porod Law applies to any
 scattering system with sharp scattering length density interfaces between the
 phases but only at very high $q$ (technically in the limit as $q \to \infty$ ..
-except of course that, practically, the continum approach breaks down there).
+except of course that, practically, the continuum approach breaks down there).
 It is based on the idea that at sufficiently high $q$ there is no shape
 information left and all scattering is just reflections off the sharp
 interfaces.
@@ -30,7 +30,7 @@ phases.
 Thus, by extracting the Porod Constant from experimental data, and
 knowing the contrast factor between the two phases, one can obtain the specific
 surface area for the material. This can be very useful for example in
-understanding porosoity in materials, particularly when used in conjunction
+understanding porosity in materials, particularly when used in conjunction
 with complementary techniques such as BET.
 
 .. Note:: While it is straightforward to calculate the specific surface area,
@@ -57,7 +57,7 @@ with complementary techniques such as BET.
       across these very sharp dips.
 
     * Ironically, large resolution smearing, and/or polydispersity smearing,
-      will make the value obtained much more consistant and reliable. Thus the
+      will make the value obtained much more consistent and reliable. Thus the
       problem is less severe for typical real data than for simulated data that
       does not simulate any resolution smearing.
 

--- a/sasmodels/models/sphere.py
+++ b/sasmodels/models/sphere.py
@@ -114,7 +114,7 @@ tests = [
     #  The number density is volume fraction divided by particle volume.
     #  Effectively, this leaves F = V drho form, where form is the usual
     #  3 j1(qr)/(qr) or whatever depending on the shape.
-    # @S RESULTS using F1 and F2 from the longer test strng above:
+    # @S RESULTS using F1 and F2 from the longer test string above:
     #
     # I(Q) = (F2 + F1^2*(S(Q) -1))*volfraction*scale/Volume  + background
     #

--- a/sasmodels/models/two_power_law.py
+++ b/sasmodels/models/two_power_law.py
@@ -12,9 +12,9 @@ The scattering intensity $I(q)$ is calculated as
     \end{cases}
 
 where $q_c$ = the location of the crossover from one slope to the other,
-$A$ = the scaling coefficent that sets the overall intensity of the lower Q
+$A$ = the scaling coefficient that sets the overall intensity of the lower Q
 power law region, $m1$ = power law exponent at low Q, and $m2$ = power law
-exponent at high Q.  The scaling of the second power law region (coefficent C)
+exponent at high Q.  The scaling of the second power law region (coefficient C)
 is then automatically scaled to match the first by following formula:
 
 .. math::
@@ -55,7 +55,7 @@ description = """
             =C*pow(qval,-1.0*power2) + background for q>q_c
             where C=coef_A*pow(q_c,-1.0*power1)/pow(q_c,-1.0*power2).
 
-            coef_A = scaling coefficent
+            coef_A = scaling coefficient
             q_c = crossover location [1/A]
             power_1 (=m1) = power law exponent at low Q
             power_2 (=m2) = power law exponent at high Q

--- a/sasmodels/models/vesicle.py
+++ b/sasmodels/models/vesicle.py
@@ -25,7 +25,7 @@ is the outer radius of the shell, $\rho_{\text{solvent}}$ is the scattering
 length density of the solvent (which is the same as for the core in this case),
 $\rho_{\text{scale}}$ is the scattering length density of the shell, background
 is a flat background level (due for example to incoherent scattering in the
-case of neutrons), and $j_1$ is the spherical bessel function
+case of neutrons), and $j_1$ is the spherical Bessel function
 $j_1 = (\sin(x) - x \cos(x))/ x^2$.
 
 The functional form is identical to a "typical" core-shell structure, except


### PR DESCRIPTION
While chasing a different issue, I noticed typos in several of the models. 

- Some of these are in comments or docstrings (first commit). 
- Some are in variable names that may impact on the ability to load old models (second commit) and a compatibility shim might be needed to fix that.