### PR TITLE
Update test discovery for pytest 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
         python -m pip install mako
-        python -m pip install numpy scipy matplotlib docutils "pytest<6" sphinx bumps unittest-xml-reporting tinycc
+        python -m pip install numpy scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc
 
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 - hash -r
 - conda update --yes conda
 - conda info -a
-- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools "pytest<6" sphinx
+- conda install --yes python=$PY numpy scipy matplotlib docutils setuptools pytest sphinx
 - conda install --yes -c conda-forge pyopencl pocl
 install:
 - pip install bumps

--- a/conftest.py
+++ b/conftest.py
@@ -53,10 +53,10 @@ def pytest_pycollect_makeitem(collector, name, obj):
     if collector.istestfunction(obj, name) and is_generator(obj):
         tests = []
         for number, yielded in enumerate(obj()):
-            index, call, args = split_yielded_test(yielded, number)
+            index, call = split_yielded_test(yielded, number)
             description = getattr(call, 'description', name+index)
             test = function_test(
-                parent=collector, name=description, args=args, callobj=call)
+                parent=collector, name=description, callobj=call)
             tests.append(test)
         return tests
 
@@ -74,13 +74,10 @@ def is_generator(func):
 def split_yielded_test(obj, number):
     if not isinstance(obj, (tuple, list)):
         obj = (obj,)
-    if not callable(obj[0]):
-        index = "['%s']"%obj[0]
-        obj = obj[1:]
-    else:
-        index = "[%d]"%number
-    call, args = obj[0], obj[1:]
-    return index, call, args
+    assert callable(obj[0])
+    index = "[%d]"%number
+    call = obj[0]
+    return index, call
 
 USE_DOCSTRING_AS_DESCRIPTION = True
 def pytest_collection_modifyitems(session, config, items):


### PR DESCRIPTION
The 'args' keyword for the pytest.Function.from_parent constructor was [removed with pytest 6.0.0rc1](https://docs.pytest.org/en/latest/changelog.html#pytest-6-0-0rc1-2020-07-08). [It was unused in pytest](https://github.com/pytest-dev/pytest/pull/7226) and in the sasmodels code `args` was always an empty tuple.

This PR removes the use of `args` which permits pytest versions from (at least) 3.10.1 to 6.0.2 to work (tested with Debian stable and unstable) plus CI on github actions.

This PR also removes the unnecessary limitation of only testing the master branch in CI, meaning that developers can actually verify that CI passes *before* creating PRs not after.

Closes: #424 