### PR TITLE
 Make sphinx nitpick-happy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,4 +62,4 @@ jobs:
     - name: check that the docs build (linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        make -j 4 -C doc SPHINXOPTS="-W --keep-going" html
+        make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,6 +25,38 @@ print("\n".join(sys.path))
 import sasmodels
 
 
+nitpick_ignore = [
+    ('py:class', 'argparse.Namespace'),
+    ('py:class', 'bumps.parameter.Parameter'),
+    ('py:class', 'collections.OrderedDict'),
+    ('py:class', 'cuda.Context'),
+    ('py:class', 'cuda.Function'),
+    ('py:class', 'np.dtype'),
+    ('py:class', 'numpy.dtype'),
+    ('py:class', 'np.ndarray'),
+    ('py:class', 'numpy.ndarray'),
+    ('py:class', 'pyopencl.Program'),
+    ('py:class', 'pyopencl._cl.Context'),
+    ('py:class', 'pyopencl._cl.CommandQueue'),
+    ('py:class', 'pyopencl._cl.Device'),
+    ('py:class', 'pyopencl._cl.Kernel'),
+    ('py:class', 'QWebView'),
+    ('py:class', 'unittest.suite.TestSuite'),
+    ('py:class', 'wx.Frame'),
+    # autodoc and namedtuple is completely broken
+    ('py:class', 'integer -- return number of occurrences of value'),
+    ('py:class', 'integer -- return first index of value.'),
+    # autodoc doesn't handle these type definitions
+    ('py:class', 'Data'),
+    ('py:class', 'Data1D'),
+    ('py:class', 'Data2D'),
+    ('py:class', 'Kernel'),
+    ('py:class', 'ModelInfo'),
+    ('py:class', 'module'),
+    ('py:class', 'SesansData'),
+    ('py:class', 'SourceModule'),
+]
+
 # -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/sasmodels/compare_many.py
+++ b/sasmodels/compare_many.py
@@ -35,7 +35,7 @@ else:
 MODELS = core.list_models()
 
 def calc_stats(target, value, index):
-    # type: (np. ndarrady, np.ndarray, Any) -> Tuple[float, float, float, float]
+    # type: (np. ndarray, np.ndarray, Any) -> Tuple[float, float, float, float]
     """
     Calculate statistics between the target value and the computed value.
 
@@ -94,7 +94,7 @@ PRECISION = {
 }
 def compare_instance(name, data, index, N=1, mono=True, cutoff=1e-5,
                      base='single', comp='double'):
-    # type: (str, Data, Any, int, bool, float, string, string) -> None
+    # type: (str, Data, Any, int, bool, float, str, str) -> None
     r"""
     Compare the model under different calculation engines.
 

--- a/sasmodels/direct_model.py
+++ b/sasmodels/direct_model.py
@@ -100,7 +100,7 @@ def call_profile(model_info, pars=None):
     return x, y, model_info.profile_axes
 
 def get_mesh(model_info, values, dim='1d', mono=False):
-    # type: (ModelInfo, Dict[str, float], str, bool) -> List[Tuple[float, np.ndarray, np.ndarry]]
+    # type: (ModelInfo, Dict[str, float], str, bool) -> List[Tuple[float, np.ndarray, np.ndarray]]
     """
     Retrieve the dispersity mesh described by the parameter set.
 

--- a/sasmodels/mixture.py
+++ b/sasmodels/mixture.py
@@ -212,7 +212,7 @@ class MixtureKernel(Kernel):
         self.results = None  # type: Callable[[], OrderedDict]
 
     def Iq(self, call_details, values, cutoff, magnetic):
-        # type: (CallDetails, np.ndarray, np.ndarry, float, bool) -> np.ndarray
+        # type: (CallDetails, np.ndarray, np.ndarray, float, bool) -> np.ndarray
         scale, background = values[0:2]
         total = 0.0
         # remember the parts for plotting later


### PR DESCRIPTION
As with https://github.com/bumps/bumps/pull/45, this PR ensures that the different code paths to running sphinx run it with the same options, fixes a few typos in some type annotations, and adds a big pile of `nitpick_ignore` entries.

Some of the ignores can hopefully be removed in the future but this seems to be what is needed to get sphinx to build cleanly at this stage.