### PR TITLE
FIX: turned magic constants to named magic constants. Refs #468

### DIFF
--- a/sasmodels/mixture.py
+++ b/sasmodels/mixture.py
@@ -18,6 +18,7 @@ from collections import OrderedDict
 import numpy as np  # type: ignore
 
 from .modelinfo import Parameter, ParameterTable, ModelInfo
+from .modelinfo import NUM_MAGFIELD_PARS, NUM_MAGNETIC_PARS, NUM_COMMON_PARS
 from .kernel import KernelModel, Kernel
 from .details import make_details
 
@@ -75,10 +76,10 @@ def make_mixture_info(parts, operation='+'):
                 # Update the parameters of this constituent model to use the
                 # new prefix
                 for par in submodel_pars:
-                    par.id = prefix + par.id[2:]
-                    par.name = prefix + par.name[2:]
+                    par.id = prefix + par.id[NUM_COMMON_PARS:]
+                    par.name = prefix + par.name[NUM_COMMON_PARS:]
                     if par.length_control is not None:
-                        par.length_control = prefix + par.length_control[2:]
+                        par.length_control = prefix + par.length_control[NUM_COMMON_PARS:]
                 i += npars
 
     for part in parts:
@@ -260,7 +261,7 @@ class _MixtureParts(object):
         self.kernels = kernels
         self.call_details = call_details
         self.values = values
-        self.spin_index = model_info.parameters.npars + 2
+        self.spin_index = model_info.parameters.npars + NUM_COMMON_PARS
         # The following are redefined by __iter__, but set them here so that
         # lint complains a little less.
         self.part_num = -1
@@ -271,8 +272,8 @@ class _MixtureParts(object):
     def __iter__(self):
         # type: () -> _MixtureParts
         self.part_num = 0
-        self.par_index = 2
-        self.mag_index = self.spin_index + 3
+        self.par_index = NUM_COMMON_PARS
+        self.mag_index = self.spin_index + NUM_MAGFIELD_PARS
         return self
 
     def __next__(self):
@@ -290,7 +291,7 @@ class _MixtureParts(object):
         self.par_index += info.parameters.npars
         if self.model_info.operation == '+':
             self.par_index += 1 # Account for each constituent model's scale param
-        self.mag_index += 3 * len(info.parameters.magnetism_index)
+        self.mag_index += NUM_MAGNETIC_PARS*len(info.parameters.magnetism_index)
 
         return kernel, call_details, values
 
@@ -307,7 +308,7 @@ class _MixtureParts(object):
         # building an addition model, each component has its own scale factor
         # which we need to skip when constructing the details for the kernel, so
         # add one, giving a net subtract one.
-        diff = 1 if self.model_info.operation == '+' else 2
+        diff = NUM_COMMON_PARS-1 if self.model_info.operation == '+' else NUM_COMMON_PARS
         index = slice(par_index - diff, par_index - diff + info.parameters.npars)
         length = full.length[index]
         offset = full.offset[index]
@@ -324,8 +325,8 @@ class _MixtureParts(object):
         pars = self.values[par_index + diff:par_index + info.parameters.npars + diff]
         nmagnetic = len(info.parameters.magnetism_index)
         if nmagnetic:
-            spin_state = self.values[self.spin_index:self.spin_index + 3]
-            mag_index = self.values[mag_index:mag_index + 3 * nmagnetic]
+            spin_state = self.values[self.spin_index:self.spin_index + NUM_MAGFIELD_PARS]
+            mag_index = self.values[mag_index:mag_index + NUM_MAGNETIC_PARS*nmagnetic]
         else:
             spin_state = []
             mag_index = []

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -53,7 +53,10 @@ COMMON_PARAMETERS = [
     ("scale", "", 1, (0.0, np.inf), "", "Scale factor or Volume fraction"),
     ("background", "1/cm", DEFAULT_BACKGROUND, (-np.inf, np.inf), "", "Source background"),
 ]
-assert (len(COMMON_PARAMETERS) == 2
+NUM_COMMON_PARS = 2
+NUM_MAGFIELD_PARS = 4
+NUM_MAGNETIC_PARS = 3  # per sld
+assert (len(COMMON_PARAMETERS) == NUM_COMMON_PARS
         and COMMON_PARAMETERS[0][0] == "scale"
         and COMMON_PARAMETERS[1][0] == "background"), "don't change common parameters"
 
@@ -445,9 +448,9 @@ class ParameterTable(object):
         self.npars = sum(p.length for p in self.kernel_parameters)
         self.nmagnetic = sum(p.length for p in self.kernel_parameters
                              if p.type == 'sld')
-        self.nvalues = 2 + self.npars
+        self.nvalues = NUM_COMMON_PARS + self.npars
         if self.nmagnetic:
-            self.nvalues += 4 + 3*self.nmagnetic
+            self.nvalues += NUM_MAGFIELD_PARS + NUM_MAGNETIC_PARS*self.nmagnetic
         self.call_parameters = self._get_call_parameters()
         self.defaults = self._get_defaults()
         #self._name_table= dict((p.id, p) for p in parameters)


### PR DESCRIPTION
Mixture models such as "cylinder+sphere" broke when an additional orientation parameter was added to the applied field for magnetic systems. This was reported in #468 as inadequate testing of models. The PR fixes the problem but does not close the testing ticket.