### PR TITLE
Update to version 1.0.6b1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Release notes
 =============
 
+v1.0.6 2022-xx-xx
+------------------
+
 v1.0.5 2021-01-26
 ------------------
 * fix probelm with P(Q) scaling when using a shell type form factors

--- a/sasmodels/__init__.py
+++ b/sasmodels/__init__.py
@@ -13,7 +13,7 @@ Models can be written in python or in C.  C models can run on the GPU if
 OpenCL drivers are available.  See :mod:`.generate` for details on
 defining new models.
 """
-__version__ = "1.0.5"
+__version__ = "1.0.6b1"
 
 def data_files():
     """


### PR DESCRIPTION
Note that LICENSE.TXT copyright date has not been updated. Also this will all need to be updated for any actual release version. Would the next one be 1.0.6rc1?