### PR TITLE
Rename magnetic angles

### DIFF
--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -590,7 +590,7 @@ def spin_weights(in_spin, out_spin):
 def orth(A, b_hat): # A = 3 x n, and b_hat unit vector
  return A - np.sum(A*b_hat[:, None], axis=0)[None, :]*b_hat[:, None]    
 
-def magnetic_sld(qx, qy, up_angle, up_phi, rho, rho_m):
+def magnetic_sld(qx, qy, up_theta, up_phi, rho, rho_m):
     """
     Compute the complex sld for the magnetic spin states.
     Returns effective rho for spin states [dd, du, ud, uu].
@@ -598,10 +598,10 @@ def magnetic_sld(qx, qy, up_angle, up_phi, rho, rho_m):
     # Handle q=0 by setting px = py = 0
     # Note: this is different from kernel_iq, which I(0,0) to 0
     q_norm = 1/sqrt(qx**2 + qy**2) if qx != 0. or qy != 0. else 0.
-    cos_spin, sin_spin = cos(radians(up_angle)), sin(radians(up_angle))
+    cos_theta, sin_theta = cos(radians(up_theta)), sin(radians(up_theta))
     cos_phi, sin_phi = cos(radians(up_phi)), sin(radians(up_phi))
     M = rho_m
-    p_hat = np.array([sin_spin * cos_phi, sin_spin * sin_phi, cos_spin ])
+    p_hat = np.array([sin_theta * cos_phi, sin_theta * sin_phi, cos_theta ])
 
     
     q_hat = np.array([qx, qy, 0]) * q_norm
@@ -622,7 +622,7 @@ def magnetic_sld(qx, qy, up_angle, up_phi, rho, rho_m):
     ]
 
 def calc_Iq_magnetic(qx, qy, rho, rho_m, points, volume=1.0, view=(0, 0, 0),
-                     up_frac_i=0.5, up_frac_f=0.5, up_angle=0., up_phi=0.):
+                     up_frac_i=0.5, up_frac_f=0.5, up_theta=0., up_phi=0.):
     """
     *qx*, *qy* correspond to the detector pixels at which to calculate the
     scattering, relative to the beam along the negative z axis.
@@ -636,7 +636,7 @@ def calc_Iq_magnetic(qx, qy, rho, rho_m, points, volume=1.0, view=(0, 0, 0),
     yaw and roll for a beam travelling along the negative z axis.
     *up_frac_i* is the portion of polarizer neutrons which are spin up.
     *up_frac_f* is the portion of analyzer neutrons which are spin up.
-    *up_angle* and *up_phi* are the rotation angle of the spin up direction 
+    *up_theta* and *up_phi* are the rotation angle of the spin up direction 
     in the detector plane and the inclination from the beam direction (z-axis).
     *dtype* is the numerical precision of the calculation. [not implemented]
     """
@@ -654,7 +654,7 @@ def calc_Iq_magnetic(qx, qy, rho, rho_m, points, volume=1.0, view=(0, 0, 0),
     qx, qy = (v.flatten() for v in (qx, qy))
     for k in range(qx.size):
         ephase = volume*np.exp(1j*(qa[k]*x + qb[k]*y + qc[k]*z))
-        dd, du, ud, uu = magnetic_sld(qx[k], qy[k], up_angle, up_phi, rho, rho_m)
+        dd, du, ud, uu = magnetic_sld(qx[k], qy[k], up_theta, up_phi, rho, rho_m)
         for w, xs in zip(weights, (dd, du, ud, uu)):
             if w == 0.0:
                 continue
@@ -1092,10 +1092,10 @@ def build_csbox(a=10, b=20, c=30, da=1, db=2, dc=3, slda=1, sldb=2, sldc=3, sld_
     return shape, fn, fn_xy
 
 def build_sphere(radius=125, rho=2,
-                 rho_m=0, theta_m=0, phi_m=0, up_i=0, up_f=0, up_angle=0, up_phi=0):
+                 rho_m=0, theta_m=0, phi_m=0, up_i=0, up_f=0, up_theta=0, up_phi=0):
     magnetism = pol2rec(rho_m, theta_m, phi_m) if rho_m != 0.0 else None
     shape = TriaxialEllipsoid(radius, radius, radius, rho, magnetism=magnetism)
-    shape.spin = (up_i, up_f, up_angle, up_phi)
+    shape.spin = (up_i, up_f, up_theta, up_phi)
     fn, fn_xy = wrap_sasmodel(
         'sphere',
         scale=1,
@@ -1108,18 +1108,18 @@ def build_sphere(radius=125, rho=2,
         sld_mphi=phi_m,
         up_frac_i=up_i,
         up_frac_f=up_f,
-        up_angle=up_angle,
+        up_theta=up_theta,
         up_phi=up_phi,
     )
     return shape, fn, fn_xy
 
 def build_ellip(rab=125, rc=50, rho=2,
-                rho_m=0, theta_m=0, phi_m=0, up_i=0, up_f=0, up_angle=0, up_phi=0):
+                rho_m=0, theta_m=0, phi_m=0, up_i=0, up_f=0, up_theta=0, up_phi=0):
     magnetism = pol2rec(rho_m, theta_m, phi_m) if rho_m != 0.0 else None
     shape = TriaxialEllipsoid(rab, rab, rc, rho, magnetism=magnetism)
     # TODO: polarization spec doesn't belong in shape
     # Put spin state info into the shape since we have it available.
-    shape.spin = (up_i, up_f, up_angle, up_phi)
+    shape.spin = (up_i, up_f, up_theta, up_phi)
     fn, fn_xy = wrap_sasmodel(
         'ellipsoid',
         scale=1,
@@ -1133,16 +1133,16 @@ def build_ellip(rab=125, rc=50, rho=2,
         sld_mphi=phi_m,
         up_frac_i=up_i,
         up_frac_f=up_f,
-        up_angle=up_angle,
+        up_theta=up_theta,
         up_phi=up_phi,
     )
     return shape, fn, fn_xy
 
 def build_triell(ra=125, rb=200, rc=50, rho=2,
-                 rho_m=0, theta_m=0, phi_m=0, up_i=0, up_f=0, up_angle=0, up_phi=0):
+                 rho_m=0, theta_m=0, phi_m=0, up_i=0, up_f=0, up_theta=0, up_phi=0):
     magnetism = pol2rec(rho_m, theta_m, phi_m) if rho_m != 0.0 else None
     shape = TriaxialEllipsoid(ra, rb, rc, rho, magnetism=magnetism)
-    shape.spin = (up_i, up_f, up_angle, up_phi)
+    shape.spin = (up_i, up_f, up_theta, up_phi)
     fn, fn_xy = wrap_sasmodel(
         'triaxial_ellipsoid',
         scale=1,
@@ -1157,7 +1157,7 @@ def build_triell(ra=125, rb=200, rc=50, rho=2,
         sld_mphi=phi_m,
         up_frac_i=up_i,
         up_frac_f=up_f,
-        up_angle=up_angle,
+        up_theta=up_theta,
         up_phi=up_phi,        
     )
     return shape, fn, fn_xy
@@ -1332,7 +1332,7 @@ def check_shape_2d(title, shape, fn=None, view=(0, 0, 0), show_points=False,
 
 def check_shape_mag(title, shape, fn=None, view=(0, 0, 0), show_points=False,
                     mesh=100, qmax=1.0, samples=5000,
-                    up_frac_i=0, up_frac_f=0, up_angle=0, up_phi=0):
+                    up_frac_i=0, up_frac_f=0, up_theta=0, up_phi=0):
     rho_solvent = 0
     #qx = np.linspace(0.0, qmax, mesh)
     #qy = np.linspace(0.0, qmax, mesh)
@@ -1351,7 +1351,7 @@ def check_shape_mag(title, shape, fn=None, view=(0, 0, 0), show_points=False,
     t0 = timer()
     Iqxy = calc_Iq_magnetic(Qx, Qy, rho, rho_m, points, volume=volume, view=view,
                             up_frac_i=up_frac_i, up_frac_f=up_frac_f,
-                            up_angle=up_angle, up_phi=up_phi)
+                            up_theta=up_theta, up_phi=up_phi)
     print("calc I_mag time", timer() - t0)
     t0 = timer()
     theory = fn(Qx, Qy, view) if fn is not None else None
@@ -1429,10 +1429,10 @@ def main():
     title = "%s(%s)" % (opts.shape, " ".join(opts.pars))
     if shape.is_magnetic:
         view = tuple(float(v) for v in opts.view.split(','))
-        up_frac_i, up_frac_f, up_angle, up_phi = shape.spin
+        up_frac_i, up_frac_f, up_theta, up_phi = shape.spin
         check_shape_mag(title, shape, fn_xy, view=view, show_points=opts.plot,
                        mesh=opts.mesh, qmax=opts.qmax, samples=opts.samples,
-                       up_frac_i=up_frac_i, up_frac_f=up_frac_f, up_angle=up_angle, up_phi=up_phi,
+                       up_frac_i=up_frac_i, up_frac_f=up_frac_f, up_theta=up_theta, up_phi=up_phi,
                        )
     elif opts.dim == 1:
         check_shape(title, shape, fn, show_points=opts.plot,

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -595,7 +595,7 @@ def parlist(model_info, pars, is2d):
     for p in parameters.user_parameters(pars, True):
         if any(p.id.endswith(x) for x in ('_M0', '_mtheta', '_mphi')):
             continue
-        if p.id in set(('up_frac_i', 'up_frac_f', 'up_angle', 'up_phi')):
+        if p.id in set(('up_frac_i', 'up_frac_f', 'up_theta', 'up_phi')):
             magnetic_pars.append("%s=%s"%(p.id, pars.get(p.id, p.default)))
             continue
         if not is2d and p.id in ('theta', 'phi', 'psi'):

--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -609,7 +609,7 @@ def parlist(model_info, pars, is2d):
             relative_pd=p.relative_pd,
             M0=pars.get(p.id+'_M0', 0.),
             mphi=pars.get(p.id+'_mphi', 0.),
-            mtheta=pars.get(p.id+'_mtheta', 0.),
+            mtheta=pars.get(p.id+'_mtheta', 90.),
         )
         lines.append(_format_par(p.name, **fields))
         magnetic = magnetic or fields['M0'] != 0.

--- a/sasmodels/conversion_table.py
+++ b/sasmodels/conversion_table.py
@@ -134,8 +134,8 @@ CONVERSION_TABLE = {
                 "M0:sld_solvent": "M0_sld_solv",
                 "mtheta:sld_solvent": "M_theta_solv",
                 "mphi:sld_solvent": "M_phi_solv",
-                "up:frac_i": "Up_frac_i",
-                "up:frac_f": "Up_frac_f",
+                "up:frac_i": "up_frac_i",
+                "up:frac_f": "up_frac_f",
                 "up:angle": "up_angle",
             }
         ],
@@ -224,8 +224,8 @@ CONVERSION_TABLE = {
                 "M0:sld_solvent": "M0_sld_solv",
                 "mtheta:sld_solvent": "M_theta_solv",
                 "mphi:sld_solvent": "M_phi_solv",
-                "up:frac_i": "Up_frac_i",
-                "up:frac_f": "Up_frac_f",
+                "up:frac_i": "up_frac_i",
+                "up:frac_f": "up_frac_f",
                 "up:angle": "up_angle"
             }
         ],
@@ -253,8 +253,8 @@ CONVERSION_TABLE = {
                 "M0:sld_solvent": "M0_sld_solv",
                 "mtheta:sld_solvent": "M_theta_solv",
                 "mphi:sld_solvent": "M_phi_solv",
-                "up:frac_i": "Up_frac_i",
-                "up:frac_f": "Up_frac_f",
+                "up:frac_i": "up_frac_i",
+                "up:frac_f": "up_frac_f",
                 "up:angle": "up_angle"
             }
         ],
@@ -585,8 +585,8 @@ CONVERSION_TABLE = {
                 "M0:sld_solvent": "M0_sld_solv",
                 "mtheta:sld_solvent": "M_theta_solv",
                 "mphi:sld_solvent": "M_phi_solv",
-                "up:frac_i": "Up_frac_i",
-                "up:frac_f": "Up_frac_f",
+                "up:frac_i": "up_frac_i",
+                "up:frac_f": "up_frac_f",
                 "up:angle": "up_angle",
             }
         ],
@@ -729,8 +729,8 @@ CONVERSION_TABLE = {
                 "M0:sld_solvent": "M0_sld_solv",
                 "mtheta:sld_solvent": "M_theta_solv",
                 "mphi:sld_solvent": "M_phi_solv",
-                "up:frac_i": "Up_frac_i",
-                "up:frac_f": "Up_frac_f",
+                "up:frac_i": "up_frac_i",
+                "up:frac_f": "up_frac_f",
                 "up:angle": "up_angle"
             }
         ],

--- a/sasmodels/conversion_table.py
+++ b/sasmodels/conversion_table.py
@@ -136,7 +136,7 @@ CONVERSION_TABLE = {
                 "mphi:sld_solvent": "M_phi_solv",
                 "up:frac_i": "Up_frac_i",
                 "up:frac_f": "Up_frac_f",
-                "up:angle": "Up_theta",
+                "up:angle": "up_angle",
             }
         ],
         "core_shell_bicelle": [
@@ -226,7 +226,7 @@ CONVERSION_TABLE = {
                 "mphi:sld_solvent": "M_phi_solv",
                 "up:frac_i": "Up_frac_i",
                 "up:frac_f": "Up_frac_f",
-                "up:angle": "Up_theta"
+                "up:angle": "up_angle"
             }
         ],
         "correlation_length": [
@@ -255,7 +255,7 @@ CONVERSION_TABLE = {
                 "mphi:sld_solvent": "M_phi_solv",
                 "up:frac_i": "Up_frac_i",
                 "up:frac_f": "Up_frac_f",
-                "up:angle": "Up_theta"
+                "up:angle": "up_angle"
             }
         ],
         "dab": [
@@ -587,7 +587,7 @@ CONVERSION_TABLE = {
                 "mphi:sld_solvent": "M_phi_solv",
                 "up:frac_i": "Up_frac_i",
                 "up:frac_f": "Up_frac_f",
-                "up:angle": "Up_theta",
+                "up:angle": "up_angle",
             }
         ],
         "peak_lorentz": [
@@ -731,7 +731,7 @@ CONVERSION_TABLE = {
                 "mphi:sld_solvent": "M_phi_solv",
                 "up:frac_i": "Up_frac_i",
                 "up:frac_f": "Up_frac_f",
-                "up:angle": "Up_theta"
+                "up:angle": "up_angle"
             }
         ],
         "spherical_sld": [

--- a/sasmodels/convert.py
+++ b/sasmodels/convert.py
@@ -195,6 +195,7 @@ def _rename_magnetic_angles(pars):
     Change name of magnetic angle.
     """
     if 'up_angle' in pars:      
+        pars['up_theta'] = 90
         pars['up_phi'] = pars['up_angle']
         pars.pop('up_angle') 
     return pars    

--- a/sasmodels/convert.py
+++ b/sasmodels/convert.py
@@ -169,6 +169,8 @@ def _hand_convert(name, oldpars, version=(3, 1, 2)):
         oldpars = _hand_convert_3_1_2_to_4_1(name, oldpars)
     if version < (4, 2, 0):
         oldpars = _rename_magnetic_pars(oldpars)
+    if version <= (5, 0, 4):
+        oldpars = _rename_magnetic_angles(oldpars)    
     return oldpars
 
 def _rename_magnetic_pars(pars):
@@ -186,6 +188,16 @@ def _rename_magnetic_pars(pars):
         elif k.startswith('up:'):
             pars['up_'+k[3:]] = pars.pop(k)
     return pars
+
+
+def _rename_magnetic_angles(pars):
+    """
+    Change name of magnetic angle.
+    """
+    if 'up_angle' in pars:      
+        pars['up_phi'] = pars['up_angle']
+        pars.pop('up_angle') 
+    return pars    
 
 def _hand_convert_3_1_2_to_4_1(name, oldpars):
     if name == 'core_shell_parallelepiped':
@@ -354,6 +366,7 @@ def convert_model(name, pars, use_underscore=False, model_version=(3, 1, 2)):
             newpars = _rescale_sld(model_info, newpars, 1e6)
         newpars.setdefault('scale', 1.0)
         newpars.setdefault('background', 0.0)
+        newpars.setdefault('up_theta', 90.0)
         if use_underscore:
             newpars = _pd_to_underscores(newpars)
         name = newname

--- a/sasmodels/kernel_iq.c
+++ b/sasmodels/kernel_iq.c
@@ -411,14 +411,14 @@ void KERNEL_NAME(
   // Interpret polarization cross section.
   //     up_frac_i = values[NUM_PARS+2];
   //     up_frac_f = values[NUM_PARS+3];
-  //     up_angle = values[NUM_PARS+4];
+  //     up_theta = values[NUM_PARS+4];
   //     up_phi = values[NUM_PARS+5];
   // TODO: could precompute more magnetism parameters before calling the kernel.
   double xs_weights[8];  // uu, ud real, du real, dd, ud imag, du imag, fill, fill
-  double cos_mspin, sin_mspin;
+  double cos_mtheta, sin_mtheta;
   double cos_mphi, sin_mphi;
   set_spin_weights(values[NUM_PARS+2], values[NUM_PARS+3], xs_weights);
-  SINCOS(values[NUM_PARS+4]*M_PI_180, sin_mspin, cos_mspin);
+  SINCOS(values[NUM_PARS+4]*M_PI_180, sin_mtheta, cos_mtheta);
   SINCOS(values[NUM_PARS+5]*M_PI_180, sin_mphi, cos_mphi);
 #endif // MAGNETIC
 
@@ -797,9 +797,9 @@ PD_OUTERMOST_WEIGHT(MAX_PD)
           const double qsq = qx * qx + qy * qy;
           if (qsq > 1.e-16) {
             // TODO: what is the magnetic scattering at q = 0
-            const double px = sin_mspin * cos_mphi;
-             const double py = sin_mspin * sin_mphi;
-            const double pz = cos_mspin;
+            const double px = sin_mtheta * cos_mphi;
+             const double py = sin_mtheta * sin_mphi;
+            const double pz = cos_mtheta;
 
             // loop over uu, ud real, du real, dd, ud imag, du imag
             for (unsigned int xs = 0; xs < 6; xs++) {

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -640,7 +640,7 @@ class ParameterTable(object):
                           'magnetic', 'fraction of spin up incident'),
                 Parameter('up_frac_f', '', 0., [0., 1.],
                           'magnetic', 'fraction of spin up final'),
-                Parameter('up_angle', 'degrees', 0., [0., 360.],
+                Parameter('up_theta', 'degrees', 0., [0., 360.],
                           'magnetic', 'polarization axis rotation angle'),
                 Parameter('up_phi', 'degrees', 0., [0., 180.],
                           'magnetic', 'polarization axis inclination angle'),
@@ -755,11 +755,11 @@ class ParameterTable(object):
             else:
                 append_group(p.id)
 
-        if is2d and 'up_angle' and 'up_phi' in expanded_pars:
+        if is2d and 'up_theta' and 'up_phi' in expanded_pars:
             result.extend([
                 expanded_pars['up_frac_i'],
                 expanded_pars['up_frac_f'],
-                expanded_pars['up_angle'],
+                expanded_pars['up_theta'],
                 expanded_pars['up_phi'],
             ])
 

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -640,7 +640,7 @@ class ParameterTable(object):
                           'magnetic', 'fraction of spin up incident'),
                 Parameter('up_frac_f', '', 0., [0., 1.],
                           'magnetic', 'fraction of spin up final'),
-                Parameter('up_theta', 'degrees', 0., [0., 360.],
+                Parameter('up_theta', 'degrees', 90., [0., 360.],
                           'magnetic', 'polarization axis rotation angle'),
                 Parameter('up_phi', 'degrees', 0., [0., 180.],
                           'magnetic', 'polarization axis inclination angle'),


### PR DESCRIPTION
This PR addresses ticket [471](https://github.com/SasView/sasmodels/issues/471). For consistency reasons, the angles describing the orientation of the polarisation should be named up_theta and up_phi  just like the particle orientation angles. This involves mainly renaming up_angle to up_theta and converting the old parameter name when loading a project from any earlier version of SASview.