### PR TITLE
explore/realspace.py cleanup

### DIFF
--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -62,8 +62,8 @@ def pol2rec(r, theta, phi):
     """
     theta, phi = radians(theta), radians(phi)
     x = +r * sin(theta) * cos(phi)
-    y = +r * sin(theta)*sin(phi) 
-    z = +r * cos(theta) 
+    y = +r * sin(theta) * sin(phi)
+    z = +r * cos(theta)
     return x, y, z
 
 def rotation(theta, phi, psi):
@@ -588,7 +588,7 @@ def spin_weights(in_spin, out_spin):
     return weight
 
 def orth(A, b_hat): # A = 3 x n, and b_hat unit vector
- return A - np.sum(A*b_hat[:, None], axis=0)[None, :]*b_hat[:, None]    
+    return A - np.sum(A*b_hat[:, None], axis=0)[None, :]*b_hat[:, None]
 
 def magnetic_sld(qx, qy, up_theta, up_phi, rho, rho_m):
     """
@@ -603,7 +603,6 @@ def magnetic_sld(qx, qy, up_theta, up_phi, rho, rho_m):
     M = rho_m
     p_hat = np.array([sin_theta * cos_phi, sin_theta * sin_phi, cos_theta ])
 
-    
     q_hat = np.array([qx, qy, 0]) * q_norm
     M_perp = orth(M,q_hat)
     M_perpP = orth(M_perp, p_hat)
@@ -612,7 +611,6 @@ def magnetic_sld(qx, qy, up_theta, up_phi, rho, rho_m):
     perpx = np.dot(p_hat, M_perp)
     perpy = np.sqrt(np.sum(M_perpP_perpQ**2, axis=0))
     perpz = np.dot(q_hat, M_perpP)
-    
 
     return [
         rho - perpx,   # dd => sld - D M_perpx
@@ -636,7 +634,7 @@ def calc_Iq_magnetic(qx, qy, rho, rho_m, points, volume=1.0, view=(0, 0, 0),
     yaw and roll for a beam travelling along the negative z axis.
     *up_frac_i* is the portion of polarizer neutrons which are spin up.
     *up_frac_f* is the portion of analyzer neutrons which are spin up.
-    *up_theta* and *up_phi* are the rotation angle of the spin up direction 
+    *up_theta* and *up_phi* are the rotation angle of the spin up direction
     in the detector plane and the inclination from the beam direction (z-axis).
     *dtype* is the numerical precision of the calculation. [not implemented]
     """
@@ -708,11 +706,11 @@ def _calc_Pr_uniform(r, rho, points, volume):
     #print("vol", np.sum(volume))
     return Pr*1e-4
 
-    # Can get an additional 2x by going to C.  Cuda/OpenCL will allow even
+    # Can get an additional 2x by going to C. Cuda/OpenCL will allow even
     # more speedup, though still bounded by the O(n^2) cost.
     """
 void pdfcalc(int n, const double *pts, const double *rho,
-         int nPr, double *Pr, double rstep)
+  int nPr, double *Pr, double rstep)
 {
   int i,j;
   for (i=0; i<n-2; i++) {
@@ -1158,7 +1156,7 @@ def build_triell(ra=125, rb=200, rc=50, rho=2,
         up_frac_i=up_i,
         up_frac_f=up_f,
         up_theta=up_theta,
-        up_phi=up_phi,        
+        up_phi=up_phi,
     )
     return shape, fn, fn_xy
 

--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -603,6 +603,7 @@ def magnetic_sld(qx, qy, up_theta, up_phi, rho, rho_m):
     # Note: this is different from kernel_iq, which I(0,0) to 0
     q_norm = 1/sqrt(qx**2 + qy**2) if qx != 0. or qy != 0. else 0.
     q_hat = np.array([qx, qy, 0]) * q_norm
+    M_perp = orth(rho_m, q_hat)  # M = rho_m
 
     # perpy_hat and perpz_hat are unit vectors spanning up the plane
     # perpendicular to polarisation for SF scattering (avoiding
@@ -613,7 +614,6 @@ def magnetic_sld(qx, qy, up_theta, up_phi, rho, rho_m):
     perpy_hat = np.array([-sin_phi, cos_phi, 0])
     perpz_hat = np.array([-cos_theta * cos_phi, -cos_theta * sin_phi, sin_theta])
 
-    M_perp = orth(rho_m, q_hat)  # M = rho_m
     perpx = p_hat @ M_perp
     perpy = perpy_hat @ M_perp
     perpz = perpz_hat @ M_perp

--- a/explore/rpa.py
+++ b/explore/rpa.py
@@ -91,7 +91,7 @@ def matrix_form(q, case_num, polys,
     else:
         A, B, C, D = polys
 
-    rho = np.matrix([[drho(p, D)] for p in (A,B,C)])
+    rho = np.array([[drho(p, D)] for p in (A,B,C)])
     S0aa = S0_ii(q, A)
     S0bb = S0_ii(q, B)
     S0cc = S0_ii(q, C)
@@ -118,7 +118,7 @@ def matrix_form(q, case_num, polys,
         S0_k = S0[:,:,k].M
         v_k = v[:,:,k].M
         S_k = np.linalg.inv(1 + S0_k*v_k)*S0_k
-        Iq[k] = rho.T * S_k * rho
+        Iq[k] = rho.T @ S_k @ rho
 
 def build_pars(case_num, polys, **interactions):
     def set_poly(x, poly):

--- a/explore/transform_angles.py
+++ b/explore/transform_angles.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+"""
+Small application to change theta, phi and psi from SasView 3.x models to the
+new angle definition in SasView 4.x and above.
+
+Usage: python explore/transform_angles.py theta phi psi
+"""
 from __future__ import print_function, division
 
 import sys
@@ -15,7 +21,7 @@ def Rx(angle):
     R = [[1, 0, 0],
          [0, +cos(a), -sin(a)],
          [0, +sin(a), +cos(a)]]
-    return np.matrix(R)
+    return np.array(R)
 
 def Ry(angle):
     """Construct a matrix to rotate points about *y* by *angle* degrees."""
@@ -23,7 +29,7 @@ def Ry(angle):
     R = [[+cos(a), 0, +sin(a)],
          [0, 1, 0],
          [-sin(a), 0, +cos(a)]]
-    return np.matrix(R)
+    return np.array(R)
 
 def Rz(angle):
     """Construct a matrix to rotate points about *z* by *angle* degrees."""
@@ -31,25 +37,25 @@ def Rz(angle):
     R = [[+cos(a), -sin(a), 0],
          [+sin(a), +cos(a), 0],
          [0, 0, 1]]
-    return np.matrix(R)
+    return np.array(R)
 
 
 def transform_angles(theta, phi, psi, qx=0.1, qy=0.1):
-    Rold = Rz(-psi)*Rx(theta)*Ry(-(90 - phi))
-    cost = lambda p: np.linalg.norm(Rz(-p[2])*Ry(-p[0])*Rz(-p[1]) - Rold)
+    Rold = Rz(-psi)@Rx(theta)@Ry(-(90 - phi))
+    cost = lambda p: np.linalg.norm(Rz(-p[2])@Ry(-p[0])@Rz(-p[1]) - Rold)
     result = fmin(cost, (theta, phi, psi))
     theta_p, phi_p, psi_p = result
-    Rnew = Rz(-psi_p)*Ry(-theta_p)*Rz(-phi_p)
+    Rnew = Rz(-psi_p)@Ry(-theta_p)@Rz(-phi_p)
 
     print("old: theta, phi, psi =", ", ".join(str(v) for v in (theta, phi, psi)))
     print("new: theta, phi, psi =", ", ".join(str(v) for v in result))
     try:
-        point = np.matrix([qx, qy, [0]*len(qx)])
+        point = np.array([qx, qy, [0]*len(qx)])
     except TypeError:
-        point = np.matrix([[qx],[qy],[0]])
+        point = np.array([[qx],[qy],[0]])
     for p in point.T:
-        print("q abc old for", p, (Rold*p.T).T)
-        print("q abc new for", p, (Rnew*p.T).T)
+        print("q abc old for", p, (Rold@p.T).T)
+        print("q abc new for", p, (Rnew@p.T).T)
 
 if __name__ == "__main__":
     theta, phi, psi = (float(v) for v in sys.argv[1:])


### PR DESCRIPTION
Some code cleanup on explore/realspace.py with minor reformatting and removing deprecated functions.

This code is not part of the sasmodels library or the sasview application. Its purpose is to validate analytical models with Monte Carlo sampling on real-space models.

To see options for running the code type:
```sh
$ python explore/realspace.py --help
```

The Pr curve should match the analytic curve but the normalization is wrong so it is shifted. The Iq_avg curve is only valid for radially symmetric samples, so in general it will not match.