### PR TITLE
Replace sas.sascalc imports with stand-alone sasdata package

### DIFF
--- a/example/sesansfit.py
+++ b/example/sesansfit.py
@@ -2,7 +2,7 @@ import logging
 
 from bumps.names import *
 from sasmodels import core, bumps_model, sesans
-from sas.sascalc.dataloader.loader import Loader
+from sasdata.dataloader.loader import Loader
 
 def get_bumps_model(model_name):
     kernel = core.load_model(model_name)

--- a/sasmodels/data.py
+++ b/sasmodels/data.py
@@ -55,9 +55,9 @@ def load_data(filename, index=0):
     Load data using a sasview loader.
     """
     try:
-        from sas.sascalc.dataloader.loader import Loader  # type: ignore
+        from sasdata.dataloader.loader import Loader  # type: ignore
     except ImportError as ie:
-        raise ImportError(f"{ie.name} is not available. Add sasview/src to the python path.")
+        raise ImportError(f"{ie.name} is not available. Add sasdata to the python path.")
     loader = Loader()
     # Allow for one part in multipart file
     if '[' in filename:
@@ -86,9 +86,9 @@ def set_beam_stop(data, radius, outer=None):
     Add a beam stop of the given *radius*.  If *outer*, make an annulus.
     """
     try:
-        from sas.sascalc.dataloader.manipulations import Ringcut
+        from sasdata.data_util.manipulations import Ringcut
     except ImportError as ie:
-        raise ImportError(f"{ie.name} is not available. Add sasview/src to the python path.")
+        raise ImportError(f"{ie.name} is not available. Add sasdata to the python path.")
     if hasattr(data, 'qx_data'):
         data.mask = Ringcut(0, radius)(data)
         if outer is not None:
@@ -105,9 +105,9 @@ def set_half(data, half):
     Select half of the data, either "right" or "left".
     """
     try:
-        from sas.sascalc.dataloader.manipulations import Boxcut
+        from sasdata.data_util.manipulations import Boxcut
     except ImportError as ie:
-        raise ImportError(f"{ie.name} is not available. Add sasview/src to the python path.")
+        raise ImportError(f"{ie.name} is not available. Add sasdata to the python path.")
     if half == 'right':
         data.mask += \
             Boxcut(x_min=-np.inf, x_max=0.0, y_min=-np.inf, y_max=np.inf)(data)
@@ -122,9 +122,9 @@ def set_top(data, cutoff):
     Chop the top off the data, above *cutoff*.
     """
     try:
-        from sas.sascalc.dataloader.manipulations import Boxcut
+        from sasdata.data_util.manipulations import Boxcut
     except ImportError as ie:
-        raise ImportError(f"{ie.name} is not available. Add sasview/src to the python path.")
+        raise ImportError(f"{ie.name} is not available. Add sasdata to the python path.")
     data.mask += \
         Boxcut(x_min=-np.inf, x_max=np.inf, y_min=-np.inf, y_max=cutoff)(data)
 

--- a/sasmodels/direct_model.py
+++ b/sasmodels/direct_model.py
@@ -165,9 +165,9 @@ def _make_sesans_transform(data):
     theta_max, theta_units = data.sample.zacceptance
     if SEunits != "A" or wunits != "A" or theta_units != "radians":
         try:
-            from sas.sascalc.data_util.nxsunit import Converter
+            from sasdata.data_util.nxsunit import Converter
         except ImportError as ie:
-            raise ImportError(f"{ie.name} is not available. Add sasview/src to the python path.")
+            raise ImportError(f"{ie.name} is not available. Add sasdata to the python path.")
 
         SElength = Converter("A")(SElength, units=SEunits)
         wavelength = Converter("A")(wavelength, units=wunits)


### PR DESCRIPTION
This replaces all sas.sascalc.dataloader imports with the stand-alone sasdata package. This is a start to allow sasmodels to be more of a stand-alone package.

This is a parallel PR to [sasview 2141](https://github.com/SasView/sasview/pull/2141)