### PR TITLE
makedirs can fail if not setting exist_ok=True

### DIFF
--- a/sasmodels/kerneldll.py
+++ b/sasmodels/kerneldll.py
@@ -267,9 +267,9 @@ def make_dll(source, model_info, dtype=F64):
     dll = dll_path(model_file, dtype)
 
     if not os.path.exists(dll):
-        # Make sure the DLL path exists.
-        if not os.path.exists(SAS_DLL_PATH):
-            os.makedirs(SAS_DLL_PATH, exist_ok=True)
+        # Make sure the DLL path exists. Use abspath since python docs warn
+        # that makedirs is not robust against '..' in path.
+        os.makedirs(os.path.abspath(SAS_DLL_PATH), exist_ok=True)
         basename = splitext(os.path.basename(dll))[0] + "_"
         system_fd, filename = tempfile.mkstemp(suffix=".c", prefix=basename)
         source = generate.convert_type(source, dtype)

--- a/sasmodels/kerneldll.py
+++ b/sasmodels/kerneldll.py
@@ -269,7 +269,7 @@ def make_dll(source, model_info, dtype=F64):
     if not os.path.exists(dll):
         # Make sure the DLL path exists.
         if not os.path.exists(SAS_DLL_PATH):
-            os.makedirs(SAS_DLL_PATH)
+            os.makedirs(SAS_DLL_PATH, exist_ok=True)
         basename = splitext(os.path.basename(dll))[0] + "_"
         system_fd, filename = tempfile.mkstemp(suffix=".c", prefix=basename)
         source = generate.convert_type(source, dtype)


### PR DESCRIPTION
I'm sure it was a weird edge-case race condition, but this code failed for me when working with a library that was using sasmodels.  I think the error can be avoided by setting "exist_ok=True" in makedirs

```
  File "/home/bbm/dev/sasmodels/sasmodels/core.py", line 132, in load_model
    return build_model(load_model_info(model_name),
  File "/home/bbm/dev/sasmodels/sasmodels/core.py", line 339, in build_model
    return kerneldll.load_dll(source['dll'], model_info, numpy_dtype)
  File "/home/bbm/dev/sasmodels/sasmodels/kerneldll.py", line 301, in load_dll
    filename = make_dll(source, model_info, dtype=dtype)
  File "/home/bbm/dev/sasmodels/sasmodels/kerneldll.py", line 272, in make_dll
    os.makedirs(SAS_DLL_PATH)
  File "/home/bbm/miniforge3/envs/saswebcalc/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/home/bbm/.sasmodels/compiled_models'
```