### PR TITLE
Doc update for Jupyter notebook scripting and bumps import issue

### DIFF
--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -10,29 +10,35 @@ Preparing your environment
 ==========================
 
 You can use python scripts to load and plot your data, create SAS models and fit parameters. You can save a script to a file such as `example/model.py` and run
-it later. However, this requires a scripting environment with the correct packages installed. Either use the SasView application itself (versions after 5.0.5), as
+it later. However, this requires a scripting environment with the correct packages installed.
+
+You can *either* use the SasView application itself (versions after 5.0.5), as
 both bumps and sasmodels are included as part of the distribution, so for
 example::
 
-    $ sasview model.py
+    > sasview model.py
  
-(Note that it may be necessary to set the path to sasmodels/sasview using *PYTHONPATH=path/to/sasmodels:path/to/sasview/src* for this to work)
+(Note that it may be necessary to first add the folder path to sasmodels/sasview
+to your *Path* environment variable for this to work; set PATH=%PATH%;C:\\your\\path\\here\\)
 
-or by creating a Python environment with pip::
+*or* create a Python environment with pip::
 
-    $ pip install sasmodels sasdata matplotlib bumps periodictable
-    $ python model.py
+    > pip install sasmodels sasdata matplotlib bumps periodictable
+    > python model.py
+
+(You can also create a Python environment using conda, see:
+https://github.com/SasView/sasview/wiki/DevNotes_CondaDevEnviroment)
 
 The pip command also works within a `Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ ::
 
-    %pip install sasmodels sasdata matplotlib bumps periodictable
+    [1]: pip install sasmodels sasdata matplotlib bumps periodictable
+
+Preparing your data
+===================
 
 The key functions are then :func:`.core.load_model` for loading the
 model definition and compiling the kernel and
 :func:`.data.load_data` for calling sasview to load the data.
-
-Preparing your data
-===================
 
 Usually you will load data via the sasview loader, with the
 :func:`.data.load_data` function.  For example::
@@ -182,7 +188,7 @@ interface. Here is an example from the *example* directory such as
 
 To run the model from your python environment use the installed *bumps* program::
 
-    $ bumps example/model.py --preview
+    >>> bumps example/model.py --preview
 
 Alternatively, on Windows, bumps can be called from the cmd prompt
 as follows::

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -35,12 +35,13 @@ The pip command also works within a `Jupyter notebook <https://docs.jupyter.org/
 
 On a Mac the command for invoking SasView will be something like::
 
-    /Applications/Sasview.app/Contents/MacOS/sasview
+    /Applications/Sasview5.dmg/Contents/MacOS/sasview
 
-This can either be used directly or can be symlinked into your path::
+depending on where it is actually installed. This can either be used directly
+or can be symlinked into your path, for example::
 
     mkdir ~/bin
-    ln -s /path/to/SasView.app/Contents/MacOS/sasview ~/bin
+    ln -s /path/to/Applications/SasView5.dmg/Contents/MacOS/sasview ~/bin
 
 Preparing your data
 ===================

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -6,9 +6,6 @@
 Scripting Interface
 *******************
 
-Need some basic details here of how to load models and data via script, evaluate
-them at given parameter values and run bumps fits.
-
 The key functions are :func:`.core.load_model` for loading the
 model definition and compiling the kernel and
 :func:`.data.load_data` for calling sasview to load the data.
@@ -118,6 +115,11 @@ Polydispersity information is set with special parameter names:
 Using sasmodels through the bumps optimizer
 ===========================================
 
+Both bumps and sasmodels are included as part of the SasView distribution. 
+The following assumes that bumps has been installed and the bumps command is
+available. Note that it may be necessary to set the path to sasmodels/sasview
+using *PYTHONPATH=path/to/sasmodels:path/to/sasview/src* to accomplish this.
+
 Like DirectModel, you can wrap data and a kernel in a *bumps* model with
 :class:`.bumps_model.Model` and create an
 :class:`.bumps_model.Experiment` that you can fit with the *bumps*
@@ -162,18 +164,18 @@ interface. Here is an example from the *example* directory such as
     M = Experiment(data=radial_data, model=model, cutoff=cutoff)
     problem = FitProblem(M)
 
-Assume that bumps has been installed and the bumps command is available.
-Maybe need to set the path to sasmodels/sasview
-using *PYTHONPATH=path/to/sasmodels:path/to/sasview/src*.
 To run the model use the *bumps* program::
 
     $ bumps example/model.py --preview
 
-Note that bumps and sasmodels are included as part of the SasView
-distribution.  On windows, bumps can be called from the cmd prompt
+Alternatively, on Windows, bumps can be called from the cmd prompt
 as follows::
 
     SasViewCom bumps.cli example/model.py --preview
+
+.. note:: The *from bumps.names import* * statement in this example will fail
+          in SasView versions 5.0.0, 5.0.1, 5.0.2, 5.0.3 and 5.0.4. Please use
+          version 4.2.2 or, better, version 5.0.5 or later.
 
 Calling the computation kernel
 ==============================
@@ -234,3 +236,17 @@ On windows, this example can be called from the cmd prompt using sasview as
 as the python interpreter::
 
     SasViewCom example/cylinder_eval.py
+
+Using sasmodels and bumps from a Jupyter notebook
+=================================================
+
+You can also use sasmodels/bumps to fit experimental data from a 
+`Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ .
+
+First install the necessary packages::
+
+    https://github.com/SasView/documents/blob/master/Notebooks/Installer.ipynb
+
+Then construct and compute the model in an analogous manner to that shown above::
+
+    https://github.com/SasView/documents/blob/master/Notebooks/sasmodels_fitting.ipynb

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -43,6 +43,30 @@ or can be symlinked into your path, for example::
     mkdir ~/bin
     ln -s /path/to/Applications/SasView5.dmg/Contents/MacOS/sasview ~/bin
 
+Command line syntax
+^^^^^^^^^^^^^^^^^^^
+
+The following use cases are recognised:
+
+    sasview
+        *Start the sasview GUI*
+
+    sasview script [args...]
+        *Run a python script using the installed SasView libraries [passing
+        optional arguments]*
+
+    sasview -m module [args...]
+        *Run a SasView/Sasmodels/Bumps module as main [passing optional arguments]*
+
+    sasview -c "python statements"
+        *Execute python statements using the installed SasView libraries*
+
+    sasview -i 
+        *Start the iPython interpreter*
+
+However, on Windows, any console output gets written to NUL by default. If
+redirecting to STDOUT does not work, try writing output to file.
+
 Preparing your data
 ===================
 

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -14,7 +14,7 @@ it later. However, this requires a scripting environment with the correct packag
 
 You can *either* use the SasView application itself (versions after 5.0.5), as
 both bumps and sasmodels are included as part of the distribution, so for
-example::
+example on Windows::
 
     > sasview model.py
  
@@ -32,6 +32,15 @@ https://github.com/SasView/sasview/wiki/DevNotes_CondaDevEnviroment)
 The pip command also works within a `Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ ::
 
     %pip install sasmodels sasdata matplotlib bumps periodictable
+
+On a Mac the command for invoking SasView will be something like::
+
+    /Applications/Sasview.app/Contents/MacOS/sasview
+
+This can either be used directly or can be symlinked into your path::
+
+    mkdir ~/bin
+    ln -s /path/to/SasView.app/Contents/MacOS/sasview ~/bin
 
 Preparing your data
 ===================

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -6,12 +6,33 @@
 Scripting Interface
 *******************
 
-The key functions are :func:`.core.load_model` for loading the
+Preparing your environment
+==========================
+
+You can use python scripts to load and plot your data, create SAS models and fit parameters. You can save a script to a file such as `example/model.py` and run
+it later. However, this requires a scripting environment with the correct packages installed. Either use the SasView application itself (versions after 5.0.5), as
+both bumps and sasmodels are included as part of the distribution, so for
+example::
+
+    $ sasview model.py
+ 
+(Note that it may be necessary to set the path to sasmodels/sasview using *PYTHONPATH=path/to/sasmodels:path/to/sasview/src* for this to work)
+
+or by creating a Python environment with pip::
+
+    $ pip install sasmodels sasdata matplotlib bumps periodictable
+    $ python model.py
+
+The pip command also works within a `Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ ::
+
+    %pip install sasmodels sasdata matplotlib bumps periodictable
+
+The key functions are then :func:`.core.load_model` for loading the
 model definition and compiling the kernel and
 :func:`.data.load_data` for calling sasview to load the data.
 
-Preparing data
-==============
+Preparing your data
+===================
 
 Usually you will load data via the sasview loader, with the
 :func:`.data.load_data` function.  For example::
@@ -115,13 +136,8 @@ Polydispersity information is set with special parameter names:
 Using sasmodels through the bumps optimizer
 ===========================================
 
-Both bumps and sasmodels are included as part of the SasView distribution. 
-The following assumes that bumps has been installed and the bumps command is
-available. Note that it may be necessary to set the path to sasmodels/sasview
-using *PYTHONPATH=path/to/sasmodels:path/to/sasview/src* to accomplish this.
-
 Like DirectModel, you can wrap data and a kernel in a *bumps* model with
-:class:`.bumps_model.Model` and create an
+:class:`.bumps_model.Model` and create a
 :class:`.bumps_model.Experiment` that you can fit with the *bumps*
 interface. Here is an example from the *example* directory such as
 *example/model.py*::
@@ -164,18 +180,14 @@ interface. Here is an example from the *example* directory such as
     M = Experiment(data=radial_data, model=model, cutoff=cutoff)
     problem = FitProblem(M)
 
-To run the model use the *bumps* program::
+To run the model from your python environment use the installed *bumps* program::
 
     $ bumps example/model.py --preview
 
 Alternatively, on Windows, bumps can be called from the cmd prompt
 as follows::
 
-    SasViewCom bumps.cli example/model.py --preview
-
-.. note:: The *from bumps.names import* * statement in this example will fail
-          in SasView versions 5.0.0, 5.0.1, 5.0.2, 5.0.3 and 5.0.4. Please use
-          version 4.2.2 or, better, version 5.0.5 or later.
+    > sasview -m bumps.cli example/model.py --preview
 
 Calling the computation kernel
 ==============================
@@ -232,21 +244,17 @@ Integrating over polydispersity and orientation, the returned values are
 $\sum_{r,w\in N(r_o, r_o/10)} \sum_\theta w F(q,r_o,\theta)\sin\theta$ and
 $\sum_{r,w\in N(r_o, r_o/10)} \sum_\theta w F^2(q,r_o,\theta)\sin\theta$.
 
-On windows, this example can be called from the cmd prompt using sasview as
+On Windows, this example can be called from the cmd prompt using sasview as
 as the python interpreter::
 
-    SasViewCom example/cylinder_eval.py
+    > sasview example/cylinder_eval.py
 
 Using sasmodels and bumps from a Jupyter notebook
 =================================================
 
 You can also use sasmodels/bumps to fit experimental data from a 
-`Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ .
+`Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ by
+constructing and computing the model in an analogous manner to that shown above.
+For an example notebook see:
 
-First install the necessary packages::
-
-    https://github.com/SasView/documents/blob/master/Notebooks/Installer.ipynb
-
-Then construct and compute the model in an analogous manner to that shown above::
-
-    https://github.com/SasView/documents/blob/master/Notebooks/sasmodels_fitting.ipynb
+https://github.com/SasView/documents/blob/master/Notebooks/sasmodels_fitting.ipynb

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -31,7 +31,7 @@ https://github.com/SasView/sasview/wiki/DevNotes_CondaDevEnviroment)
 
 The pip command also works within a `Jupyter notebook <https://docs.jupyter.org/en/latest/install.html>`_ ::
 
-    [1]: pip install sasmodels sasdata matplotlib bumps periodictable
+    %pip install sasmodels sasdata matplotlib bumps periodictable
 
 Preparing your data
 ===================

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -518,7 +518,7 @@ def eval_form(q, form, pars):
     """
     Return the SAS model evaluated at *q*.
 
-    *form* is the SAS model returned from :fun:`core.load_model`.
+    *form* is the SAS model returned from :func:`core.load_model`.
 
     *pars* are the parameter values to use when evaluating.
     """


### PR DESCRIPTION
This PR addresses an issue raised by User RobD who had been trying to utilise the scripting example but found it did not work. The reason for this turned out to be two-fold:

First, the need to have pre-installed sasmodels and bumps came after the fact. The sequencing of relevant passages has been changed to address this. At the same time, links to more recent Jupyter notebook tutorials have also been added.

Second, it transpired that the included example contained an import statement that did not work in all versions of SasView! Very bizzarely, _from bumps.names import *_ works in 4.2.2 and 5.0.5 **but not** in any intermediate version of SasView. The reason for this is still unclear. However, for future reference a clarifying note has been added to the scripting help.