### PR TITLE
Change slit nomenclature from qx-qy to width-length

### DIFF
--- a/doc/guide/resolution.rst
+++ b/doc/guide/resolution.rst
@@ -69,7 +69,7 @@ where *Norm* is given by
 **[Equation 1]**
 
 The functions $W_v(v)$ and $W_u(u)$ refer to the slit width weighting
-function and the slit height weighting determined at the given $q$ point,
+function and the slit length weighting determined at the given $q$ point,
 respectively. It is assumed that the weighting function is described by a
 rectangular function, such that
 
@@ -86,7 +86,7 @@ and
 so that $\Delta q_\alpha = \int_0^\infty d\alpha\, W_\alpha(\alpha)$
 for $\alpha$ as $v$ and $u$.
 
-Here $\Delta q_u$ and $\Delta q_v$ stand for the the slit height (FWHM/2)
+Here $\Delta q_u$ and $\Delta q_v$ stand for the the slit length (FWHM/2)
 and the slit width (FWHM/2) in $q$ space.
 
 This simplifies the integral in Equation 1 to
@@ -152,13 +152,13 @@ Solution 3
 **For** $\Delta q_v = \text{constant}$ **and** $\Delta q_u = \text{constant}$
 
 In this case, the best way is to perform the integration of Equation 1
-numerically for both slit height and slit width. However, the numerical
+numerically for both slit length and slit width. However, the numerical
 integration is imperfect unless a large number of iterations, say, at
 least 10000 by 10000 for each element of the matrix $W$, is performed.
 This is usually too slow for routine use.
 
 An alternative approach is used in sasmodels which assumes
-slit width << slit height. This method combines Solution 1 with the
+slit width << slit length. This method combines Solution 1 with the
 numerical integration for the slit width. Then
 
 .. math::

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -122,7 +122,7 @@ class Slit1D(Resolution):
     The *weight_matrix* is computed by :func:`slit_resolution`
 
     """
-    
+
     def __init__(self, q, q_length, q_width=0., q_calc=None):
         # Remember what width/dqy was used even though we won't need them
         # after the weight matrix is constructed
@@ -331,11 +331,12 @@ def slit_resolution(q_calc, q, width, length, n_length=30):
 
 
     """
-    #np.set_printoptions(precision=6, linewidth=10000)
+
+    # np.set_printoptions(precision=6, linewidth=10000)
 
     # The current algorithm is a midpoint rectangle rule.
     q_edges = bin_edges(q_calc) # Note: requires q > 0
-    #q_edges[q_edges < 0.0] = 0.0 # clip edges below zero
+    # q_edges[q_edges < 0.0] = 0.0 # clip edges below zero
     weights = np.zeros((len(q), len(q_calc)), 'd')
 
     #print(q_calc)
@@ -1130,7 +1131,7 @@ def _eval_demo_1d(resolution, title):
     Iq = resolution.apply(theory)
 
     if isinstance(resolution, Slit1D):
-        width, length = resolution.qx_width, resolution.qy_width
+        width, length = resolution.q_width, resolution.q_length
         Iq_romb = romberg_slit_1d(resolution.q, width, length, model, pars)
     else:
         dq = resolution.q_width

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -35,8 +35,8 @@ class Resolution(object):
 
     *apply* is the method to call with I(q_calc) to compute the resolution
     smeared theory I(q).
-
     """
+
     q = None  # type: np.ndarray
     q_calc = None  # type: np.ndarray
     def apply(self, theory):
@@ -122,6 +122,7 @@ class Slit1D(Resolution):
     The *weight_matrix* is computed by :func:`slit_resolution`
 
     """
+    
     def __init__(self, q, q_length, q_width=0., q_calc=None):
         # Remember what width/dqy was used even though we won't need them
         # after the weight matrix is constructed

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -870,9 +870,9 @@ class IgorComparisonTest(unittest.TestCase):
             }
         form = load_model('ellipsoid', dtype='double')
         q = np.logspace(log10(4e-5), log10(2.5e-2), 68)
-        length, width = 0.,0.117
+        width, length = 0.,0.117
         resolution = Slit1D(q, q_length=length, q_width=width)
-        answer = romberg_slit_1d(q, width, length, form, pars)
+        answer = romberg_slit_1d(q, length, width, form, pars)
         output = resolution.apply(eval_form(resolution.q_calc, form, pars))
         # TODO: 10% is too much error; use better algorithm
         #print(np.max(abs(answer-output)/answer))

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -1161,13 +1161,13 @@ def demo_slit_1d():
     Show example of slit smearing.
     """
     q = np.logspace(-4, np.log10(0.2), 100)
-    w = h = 0.
+    w = l = 0.
     #w = 0.000000277790
     w = 0.0277790
-    #h = 0.00277790
-    #h = 0.0277790
-    resolution = Slit1D(q, w, h)
-    _eval_demo_1d(resolution, title="(%g,%g) Slit Resolution"%(w, h))
+    #l = 0.00277790
+    #l = 0.0277790
+    resolution = Slit1D(q, w, l)
+    _eval_demo_1d(resolution, title="(%g,%g) Slit Resolution"%(w, l))
 
 def demo():
     """

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -35,6 +35,7 @@ class Resolution(object):
 
     *apply* is the method to call with I(q_calc) to compute the resolution
     smeared theory I(q).
+    
     """
 
     q = None  # type: np.ndarray
@@ -212,7 +213,7 @@ def slit_resolution(q_calc, q, width, length, n_length=30):
     r"""
     Build a weight matrix to compute *I_s(q)* from *I(q_calc)*, given
     $q_\perp$ = *width* (in the high-resolution axis) and $q_\parallel$
-     = *length* (in the low resolution axis).  *length* is the number
+    = *length* (in the low resolution axis).  *length* is the number
     of steps to use in the integration over $q_\parallel$ when both
     $q_\perp$ and $q_\parallel$ are non-zero.
 

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -35,6 +35,7 @@ class Resolution(object):
 
     *apply* is the method to call with I(q_calc) to compute the resolution
     smeared theory I(q).
+
     """
     q = None  # type: np.ndarray
     q_calc = None  # type: np.ndarray
@@ -119,6 +120,7 @@ class Slit1D(Resolution):
     be estimated from the *q* and *q_width*.
 
     The *weight_matrix* is computed by :func:`slit_resolution`
+
     """
     def __init__(self, q, qx_width, qy_width=0., q_calc=None):
         # Remember what width/dqy was used even though we won't need them

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -565,7 +565,7 @@ def romberg_slit_1d(q, width, length, form, pars):
     if np.isscalar(length):
         length = [length]*len(q)
     _int_w = lambda w, qi: eval_form(sqrt(qi**2 + w**2), form, pars)
-    _int_h = lambda h, qi: eval_form(abs(qi+h), form, pars)
+    _int_l = lambda l, qi: eval_form(abs(qi+l), form, pars)
     # If both width and length are defined, then it is too slow to use dblquad.
     # Instead use trapz on a fixed grid, interpolated into the I(Q) for
     # the extended Q range.
@@ -584,11 +584,11 @@ def romberg_slit_1d(q, width, length, form, pars):
             result[i] = total/(2*l)
         else:
             w_grid = np.linspace(0, w, 21)[None, :]
-            h_grid = np.linspace(-l, l, 23)[:, None]
-            u_sub = sqrt((qi+h_grid)**2 + w_grid**2)
+            l_grid = np.linspace(-l, l, 23)[:, None]
+            u_sub = sqrt((qi+l_grid)**2 + w_grid**2)
             f_at_u = np.interp(u_sub, q_calc, Iq)
             #print(np.trapz(Iu, w_grid, axis=1))
-            total = np.trapz(np.trapz(f_at_u, w_grid, axis=1), h_grid[:, 0])
+            total = np.trapz(np.trapz(f_at_u, w_grid, axis=1), l_grid[:, 0])
             result[i] = total / (2*l*w)
             # from scipy.integrate import dblquad
             # r, err = dblquad(_int_wh, -h, h, lambda h: 0., lambda h: w,

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -112,9 +112,9 @@ class Slit1D(Resolution):
 
     *q* points at which the data is measured.
 
-    *qx_width* slit width (short axis) in qx
+    *q_width* slit width (short axis); deprecated nomenclature qy
 
-    *qy_width* slit length (long axis) in qy
+    *q_length* slit length (long axis); deprecated nomenclature qx
 
     *q_calc* is the list of points to calculate, or None if this should
     be estimated from the *q* and *q_width*.
@@ -122,24 +122,24 @@ class Slit1D(Resolution):
     The *weight_matrix* is computed by :func:`slit_resolution`
 
     """
-    def __init__(self, q, qx_width, qy_width=0., q_calc=None):
+    def __init__(self, q, q_length, q_width=0., q_calc=None):
         # Remember what width/dqy was used even though we won't need them
         # after the weight matrix is constructed
-        self.qx_width, self.qy_width = qx_width, qy_width
+        self.q_length, self.q_width = q_length, q_width
 
         # Allow independent resolution on each point even though it is not
         # needed in practice.
-        if np.isscalar(qx_width):
-            qx_width = np.ones(len(q))*qx_width
+        if np.isscalar(q_width):
+            q_width = np.ones(len(q))*q_width
         else:
-            qx_width = np.asarray(qx_width)
-        if np.isscalar(qy_width):
-            qy_width = np.ones(len(q))*qy_width
+            q_width = np.asarray(q_width)
+        if np.isscalar(q_length):
+            q_length = np.ones(len(q))*q_length
         else:
-            qy_width = np.asarray(qy_width)
+            q_length = np.asarray(q_length)
 
         self.q = q.flatten()
-        self.q_calc = slit_extend_q(q, qx_width, qy_width) \
+        self.q_calc = slit_extend_q(q, q_width, q_length) \
             if q_calc is None else np.sort(q_calc)
 
         # Protect against models which are not defined for very low q.  Limit
@@ -149,7 +149,7 @@ class Slit1D(Resolution):
 
         # Build weight matrix from calculated q values
         self.weight_matrix = \
-            slit_resolution(self.q_calc, self.q, qx_width, qy_width)
+            slit_resolution(self.q_calc, self.q, q_length, q_width)
         self.q_calc = abs(self.q_calc)
 
     def apply(self, theory):

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -344,14 +344,14 @@ def slit_resolution(q_calc, q, width, length, n_length=30):
             # up qi in q_calc, then weighting the result by the relative
             # distance to the neighbouring points.
             weights[i, :] = (q_calc == qi)
-        elif h == 0:
+        elif l == 0:
             weights[i, :] = _q_perp_weights(q_edges, qi, w)
         elif w == 0:
             in_x = 1.0 * ((q_calc >= qi-l) & (q_calc <= qi+l))
             abs_x = 1.0*(q_calc < abs(qi - l)) if qi < l else 0.
             #print(qi - l, qi + l)
             #print(in_x + abs_x)
-            weights[i, :] = (in_x + abs_x) * np.diff(q_edges) / (2*h)
+            weights[i, :] = (in_x + abs_x) * np.diff(q_edges) / (2*l)
         else:
             for k in range(-n_length, n_length+1):
                 weights[i, :] += _q_perp_weights(q_edges, qi+k*l/n_length, w)

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -870,8 +870,8 @@ class IgorComparisonTest(unittest.TestCase):
             }
         form = load_model('ellipsoid', dtype='double')
         q = np.logspace(log10(4e-5), log10(2.5e-2), 68)
-        width, length = 0.117, 0.
-        resolution = Slit1D(q, q_width=width, q_length=length)
+        width, length = 0.,0.117
+        resolution = Slit1D(q, q_length=length, q_width=width)
         answer = romberg_slit_1d(q, width, length, form, pars)
         output = resolution.apply(eval_form(resolution.q_calc, form, pars))
         # TODO: 10% is too much error; use better algorithm

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -649,7 +649,7 @@ class ResolutionTest(unittest.TestCase):
         """
         Slit smearing with perfect resolution.
         """
-        resolution = Slit1D(self.x, qx_width=0, qy_width=0, q_calc=self.x)
+        resolution = Slit1D(self.x, q_length=0, q_width=0, q_calc=self.x)
         theory = self.Iq(resolution.q_calc)
         output = resolution.apply(theory)
         np.testing.assert_equal(output, self.y)
@@ -659,7 +659,7 @@ class ResolutionTest(unittest.TestCase):
         """
         Slit smearing with length 0.005
         """
-        resolution = Slit1D(self.x, qx_width=0, qy_width=0.005, q_calc=self.x)
+        resolution = Slit1D(self.x, q_width=0, q_length=0.005, q_calc=self.x)
         theory = self.Iq(resolution.q_calc)
         output = resolution.apply(theory)
         answer = [
@@ -674,7 +674,7 @@ class ResolutionTest(unittest.TestCase):
         Slit smearing with width < 100*length.
         """
         q = np.logspace(-4, -1, 10)
-        resolution = Slit1D(q, qx_width=0.2, qy_width=np.inf)
+        resolution = Slit1D(q, q_width=0.2, q_length=np.inf)
         theory = 1000*self.Iq(resolution.q_calc**4)
         output = resolution.apply(theory)
         answer = [
@@ -688,7 +688,7 @@ class ResolutionTest(unittest.TestCase):
         """
         Slit smearing with width 0.0002
         """
-        resolution = Slit1D(self.x, qx_width=0.0002, qy_width=0, q_calc=self.x)
+        resolution = Slit1D(self.x, q_width=0.0002, q_length=0, q_calc=self.x)
         theory = self.Iq(resolution.q_calc)
         output = resolution.apply(theory)
         answer = [
@@ -701,7 +701,7 @@ class ResolutionTest(unittest.TestCase):
         """
         Slit smearing with width > 100*length.
         """
-        resolution = Slit1D(self.x, qx_width=0.0002, qy_width=0.000001,
+        resolution = Slit1D(self.x, q_width=0.0002, q_length=0.000001,
                             q_calc=self.x)
         theory = self.Iq(resolution.q_calc)
         output = resolution.apply(theory)
@@ -834,7 +834,7 @@ class IgorComparisonTest(unittest.TestCase):
 
         data = np.loadtxt(data_string.split('\n')).T
         q, delta_qv, _, answer = data
-        resolution = Slit1D(q, qx_width=delta_qv, qy_width=0)
+        resolution = Slit1D(q, q_length=delta_qv, q_width=0)
         output = self._eval_sphere(pars, resolution)
         # TODO: eliminate Igor test since it is too inaccurate to be useful.
         # This means we can eliminate the test data as well, and instead
@@ -853,7 +853,7 @@ class IgorComparisonTest(unittest.TestCase):
         answer = romberg_slit_1d(q, delta_qv, 0., self.model, pars)
         q_calc = slit_extend_q(interpolate(q, 2*np.pi/pars['radius']/20),
                                delta_qv[0], 0.)
-        resolution = Slit1D(q, qx_width=delta_qv, qy_width=0, q_calc=q_calc)
+        resolution = Slit1D(q, q_length=delta_qv, q_width=0, q_calc=q_calc)
         output = self._eval_sphere(pars, resolution)
         # TODO: relative error should be lower
         self._compare(q, output, answer, 0.025)
@@ -871,7 +871,7 @@ class IgorComparisonTest(unittest.TestCase):
         form = load_model('ellipsoid', dtype='double')
         q = np.logspace(log10(4e-5), log10(2.5e-2), 68)
         width, length = 0.117, 0.
-        resolution = Slit1D(q, qx_width=width, qy_width=length)
+        resolution = Slit1D(q, q_width=width, q_length=length)
         answer = romberg_slit_1d(q, width, length, form, pars)
         output = resolution.apply(eval_form(resolution.q_calc, form, pars))
         # TODO: 10% is too much error; use better algorithm

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -870,7 +870,7 @@ class IgorComparisonTest(unittest.TestCase):
             }
         form = load_model('ellipsoid', dtype='double')
         q = np.logspace(log10(4e-5), log10(2.5e-2), 68)
-        width, length = 0.,0.117
+        length, width = 0.,0.117
         resolution = Slit1D(q, q_length=length, q_width=width)
         answer = romberg_slit_1d(q, width, length, form, pars)
         output = resolution.apply(eval_form(resolution.q_calc, form, pars))

--- a/sasmodels/resolution2d.py
+++ b/sasmodels/resolution2d.py
@@ -186,6 +186,11 @@ class Slit2D(Resolution):
     *q_width* slit width (short axis); assumed to be in the direction of qy; current implementation requires a fixed
     q_width for all q points.
 
+    Please note that this assumption of laboratory-frame qx and qy directions can be inverted by adding or subtracting
+    90 degrees from the model orientation.  For the particular case of USANS, which has a vertical slit of width
+    *q_width* sweeping through qx, add 90 degrees to the fitted phi angle to find the orientation relative to laboratory
+    frame.
+
     *q_calc* is the list of q points to calculate, or None if this
     should be estimated from the *q* and *qx_width*.
 


### PR DESCRIPTION
As discussed at length in sasview/sasview#1753 and described here in #528 this changes the nomenclature throughout from the confusing qx_width and qy_width to the canSAS standard q_length and q_width, where length is the long axis of the slit and width the short axis.

This depends on and is linked to issue sasview/sasview#1753 and PR sasview/sasview#2283