### PR TITLE
Update scripting Part Deux

### DIFF
--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -19,7 +19,8 @@ example on Windows::
     > sasview model.py
  
 (Note that it may be necessary to first add the folder path to sasmodels/sasview
-to your *Path* environment variable for this to work; set PATH=%PATH%;C:\\your\\path\\here\\)
+to your *Path* environment variable for this to work; set PATH=%PATH%;C:\\your\\path\\here\\ . The folder path can be found in the
+Help > About box if you are running the SasView GUI.)
 
 *or* create a Python environment with pip::
 
@@ -46,26 +47,7 @@ or can be symlinked into your path, for example::
 Command line syntax
 ^^^^^^^^^^^^^^^^^^^
 
-The following use cases are recognised:
-
-    sasview
-        *Start the sasview GUI*
-
-    sasview script [args...]
-        *Run a python script using the installed SasView libraries [passing
-        optional arguments]*
-
-    sasview -m module [args...]
-        *Run a SasView/Sasmodels/Bumps module as main [passing optional arguments]*
-
-    sasview -c "python statements"
-        *Execute python statements using the installed SasView libraries*
-
-    sasview -i 
-        *Start the iPython interpreter*
-
-However, on Windows, any console output gets written to NUL by default. If
-redirecting to STDOUT does not work, try writing output to file.
+For details of the supported command syntax, see :mod:`sas.cli`.
 
 Preparing your data
 ===================

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -47,7 +47,7 @@ or can be symlinked into your path, for example::
 Command line syntax
 ^^^^^^^^^^^^^^^^^^^
 
-For details of the supported command syntax, see :mod:`sas.cli`.
+For details of the supported command syntax, see :mod:`sas.cli` .
 
 Preparing your data
 ===================

--- a/doc/guide/scripting.rst
+++ b/doc/guide/scripting.rst
@@ -44,11 +44,6 @@ or can be symlinked into your path, for example::
     mkdir ~/bin
     ln -s /path/to/Applications/SasView5.dmg/Contents/MacOS/sasview ~/bin
 
-Command line syntax
-^^^^^^^^^^^^^^^^^^^
-
-For details of the supported command syntax, see :mod:`sas.cli` .
-
 Preparing your data
 ===================
 


### PR DESCRIPTION
This PR partially reverts recent changes already made to scripting.rst in favour of locating the doc strings in sas\cli.py. See https://github.com/SasView/sasview/pull/2280