### PR TITLE
Restructuring and cross-linking of sasmodels docs

### DIFF
--- a/doc/guide/fitting_sq.rst
+++ b/doc/guide/fitting_sq.rst
@@ -7,12 +7,12 @@
 .. _Interaction_Models:
 
 Fitting Models with Structure Factors
--------------------------------------
+=====================================
 
 **Interaction models** (previously called product models), or $P@S$ models
 for short, multiply the form factor $P(Q)$ by the structure factor $S(Q)$,
 modulated by the **effective radius** of the form factor. For the theory
-behind this, see :ref:`PStheory` later.
+behind this, see :ref:`PStheory` .
 
 Parameters
 ^^^^^^^^^^
@@ -151,148 +151,25 @@ Many parameters are common amongst $P@S$ models, but take on specific meanings:
     More mode options may appear in future as more complicated operations are
     added.
 
-.. _PStheory:
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
-Theory
-^^^^^^
+Related sections
+^^^^^^^^^^^^^^^^
 
-Scattering at vector $\mathbf Q$ for an individual particle with
-shape parameters $\mathbf\xi$ and contrast $\rho_c(\mathbf r, \mathbf\xi)$
-is computed from the square of the amplitude, $F(\mathbf Q, \mathbf\xi)$, as
+See also:
 
-.. math::
-    I(\mathbf Q) = F(\mathbf Q, \mathbf\xi) F^*(\mathbf Q, \mathbf\xi)
-        \big/ V(\mathbf\xi)
+:ref:`PStheory`
 
-with the particle volume $V(\mathbf \xi)$ and
+:ref:`polydispersityhelp`
 
-.. math::
-    F(\mathbf Q, \mathbf\xi) = \int_{\mathbb R^3} \rho_c(\mathbf r, \mathbf\xi)
-        e^{i \mathbf Q \cdot \mathbf r} \,\mathrm d \mathbf r = F
+:ref:`Resolution_Smearing`
 
-The 1-D scattering pattern for monodisperse particles uses the orientation
-average in spherical coordinates,
-
-.. math::
-    I(Q) = n \langle F F^*\rangle = \frac{n}{4\pi}
-    \int_{\theta=0}^{\pi} \int_{\phi=0}^{2\pi}
-    F F^* \sin(\theta) \,\mathrm d\phi \mathrm d\theta
-
-where $F(\mathbf Q,\mathbf\xi)$ uses
-$\mathbf Q = [Q \sin\theta\cos\phi, Q \sin\theta\sin\phi, Q \cos\theta]^T$.
-A $u$-substitution may be used, with $\alpha = \cos \theta$,
-$\surd(1 - \alpha^2) = \sin \theta$, and
-$\mathrm d\alpha = -\sin\theta\,\mathrm d\theta$.
-Here,
-
-.. math:: n = V_f/V(\mathbf\xi)
-
-is the number density of scatterers estimated from the volume fraction $V_f$
-of particles in solution. In this formalism, each incoming
-wave interacts with exactly one particle before being scattered into the
-detector. All interference effects are within the particle itself.
-The detector accumulates counts in proportion to the relative probability
-at each pixel. The extension to heterogeneous systems is simply a matter of
-adding the scattering patterns in proportion to the number density of each
-particle. That is, given shape parameters $\mathbf\xi$ with probability
-$P_\mathbf{\xi}$,
-
-.. math::
-
-    I(Q) = \int_\Xi n(\mathbf\xi) \langle F F^* \rangle \,\mathrm d\xi
-         = V_f\frac{\int_\Xi P_\mathbf{\xi} \langle F F^* \rangle
-         \,\mathrm d\mathbf\xi}{\int_\Xi P_\mathbf\xi V(\mathbf\xi)\,\mathrm d\mathbf\xi}
-
-This approximation is valid in the dilute limit, where particles are
-sufficiently far apart that the interaction between them can be ignored.
-
-As concentration increases, a structure factor term $S(Q)$ can be included,
-giving the monodisperse approximation for the interaction between particles,
-with
-
-.. math:: I(Q) = n \langle F F^* \rangle S(Q)
-
-For particles without spherical symmetry, the decoupling approximation
-is more accurate, with
-
-.. math::
-
-    I(Q) = n [\langle F F^* \rangle
-        + \langle F \rangle \langle F \rangle^* (S(Q) - 1)]
-
-Or equivalently,
-
-.. math:: I(Q) = P(Q)[1 + \beta\,(S(Q) - 1)]
-
-with the form factor $P(Q) = n \langle F F^* \rangle$ and
-$\beta = \langle F \rangle \langle F \rangle^* \big/ \langle F F^* \rangle$.
-These approximations can be extended to heterogeneous systems using averages
-over size, $\langle \cdot \rangle_\mathbf\xi = \int_\Xi P_\mathbf\xi \langle\cdot\rangle\,\mathrm d\mathbf\xi \big/ \int_\Xi P_\mathbf\xi \,\mathrm d\mathbf\xi$ and setting
-$n = V_f\big/\langle V \rangle_\mathbf\xi$.
-
-Further improvements can be made using the local monodisperse
-approximation (LMA) or using partial structure factors as done in [#bressler]_,
-but these are not implemented in this code.
-
-For hollow shapes, *volfraction* is computed from the material in the
-shell rather than the shell plus solvent inside the shell.  Using
-$V_e(\mathbf\xi)$ as the enclosed volume of the shell plus solvent and
-$V_c(\mathbf\xi)$ as the core volume of solvent inside the shell, we
-can compute the average enclosed and shell volumes as
-
-.. math::
-    :nowrap:
-
-    \begin{align*}
-    \langle V_e \rangle &= \frac{
-        \int_\Xi P_\mathbf\xi V_e(\mathbf\xi)\,\mathrm d\mathbf\xi
-    }{ \int_\Xi P_\mathbf\xi\,\mathrm d\mathbf \xi } \\
-    \langle V_s \rangle &= \frac{
-        \int_\Xi P_\mathbf\xi (V_e(\mathbf\xi) - V_c(\mathbf\xi))\,\mathrm d\mathbf\xi
-    }{ \int_\Xi P_\mathbf\xi\,\mathrm d\mathbf \xi }
-    \end{align*}
-
-Given $n$ particles and a total solvent volume $V_\text{out}$ outside the
-shells, the volume fraction of the shell, $\phi_s$ and the shell plus
-enclosed solvent $\phi_e$ are
-
-.. math::
-    :nowrap:
-
-    \begin{align*}
-    \phi_s &= \frac{n \langle V_s \rangle}{n \langle V_s \rangle + n \langle V_c \rangle + V_\text{out}}
-           = \frac{n \langle V_s \rangle}{V_\text{total}} \\
-    \phi_e &= \frac{n \langle V_e \rangle}{n \langle V_e \rangle + V_\text{out}}
-           = \frac{n \langle V_e \rangle}{V_\text{total}}
-    \end{align*}
-
-Dividing gives
-
-.. math::
-
-    \frac{\phi_S}{\phi_P} = \frac{\langle V_e \rangle}{\langle V_s \rangle}
-
-so the enclosed volume fraction can be computed from the shell volume fraction
-and the form:shell volume ratio as
-
-.. math::
-
-    \phi_S = \phi_P \langle V_e \rangle \big/ \langle V_s \rangle
-
-.. note::
-
-    Prior to Sasmodels v1.0.5 (Nov 2020), the intermediate $P(Q)$ returned by
-    the interaction calculator did not incorporate the volume normalization and
-    so $I(Q) \ne P(Q) S(Q)$. This became apparent when $P(Q)$ and $I(Q)$ were
-    plotted together. Further details can be found `here <https://github.com/SasView/sasview/issues/1698>`_.
+:ref:`orientation`
 
 References
 ^^^^^^^^^^
 
 .. [#kotlarchyk] Kotlarchyk, M.; Chen, S.-H. *J. Chem. Phys.*, 1983, 79, 2461
-
-.. [#bressler] Bressler I., Kohlbrecher J., Thunemann A.F.
-   *J. Appl. Crystallogr.* 48 (2015) 1587-1598
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
@@ -300,3 +177,4 @@ References
 
 | 2019-03-31 Paul Kienzle, Steve King & Richard Heenan
 | 2021-11-03 Steve King
+| 2022-10-30 Steve King

--- a/doc/guide/index.rst
+++ b/doc/guide/index.rst
@@ -1,6 +1,6 @@
-****************
-SAS Models Guide
-****************
+***************
+Sasmodels Guide
+***************
 
 .. toctree::
    :numbered: 4
@@ -8,14 +8,15 @@ SAS Models Guide
 
    intro.rst
    install.rst
+   scripting.rst
    gpu_setup.rst
+   theory.rst
    pd/polydispersity.rst
    resolution.rst
-   plugin.rst
    fitting_sq.rst
-   magnetism/magnetism.rst
    orientation/orientation.rst
+   magnetism/magnetism.rst
+   plugin.rst
    sesans/sans_to_sesans.rst
    sesans/sesans_fitting.rst
-   scripting.rst
    refs.rst

--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -1,9 +1,9 @@
 ********************
-sasmodels Setup
+Sasmodels setup
 ********************
 
 
-sasmodels Installation
+Sasmodels Installation
 **********************
 Sasmodels can be installed using a simple pip installation::
 

--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -1,5 +1,5 @@
 ********************
-Sasmodels setup
+Sasmodels Setup
 ********************
 
 

--- a/doc/guide/orientation/orientation.rst
+++ b/doc/guide/orientation/orientation.rst
@@ -1,6 +1,6 @@
 .. _orientation:
 
-Oriented particles
+Oriented Particles
 ==================
 
 With two dimensional small angle diffraction data sasmodels will calculate
@@ -198,8 +198,27 @@ it difficult to control.  Now, rotation in $\theta$ modifies the spacings
 in the refraction pattern, and rotation in $\phi$ rotates it in the detector
 plane.
 
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
+Related sections
+^^^^^^^^^^^^^^^^
+
+See also:
+
+**Orientation explorer** :mod:`sasmodels.jitter`
+
+:ref:`PStheory`
+
+:ref:`polydispersityhelp`
+
+:ref:`Resolution_Smearing`
+
+:ref:`Interaction_Models`
+
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
 *Document History*
 
 | 2017-11-06 Richard Heenan
 | 2017-12-20 Paul Kienzle
+| 2022-10-30 Steve King

--- a/doc/guide/pd/polydispersity.rst
+++ b/doc/guide/pd/polydispersity.rst
@@ -8,7 +8,7 @@
 .. _polydispersityhelp:
 
 Polydispersity & Orientational Distributions
---------------------------------------------
+============================================
 
 For some models we can calculate the average intensity for a population of
 particles that possess size and/or orientational (ie, angular) distributions
@@ -22,14 +22,14 @@ that
 
 .. math::
 
-  P(q) = \text{scale} \langle F^* F \rangle / V + \text{background}
+  P(q) = \frac{\text{scale}}{\langle V \rangle} \langle F F^* \rangle + \text{background}
 
 where $F$ is the scattering amplitude and $\langle\cdot\rangle$ denotes an
 average over the distribution $f(x; \bar x, \sigma)$, giving
 
 .. math::
 
-  P(q) = \frac{\text{scale}}{V} \int_\mathbb{R}
+  P(q) = \frac{\text{scale}}{\langle V \rangle} \int_\mathbb{R}
   f(x; \bar x, \sigma) F^2(q, x)\, dx + \text{background}
 
 Each distribution is characterized by a center value $\bar x$ or
@@ -85,6 +85,82 @@ Distribution but this may not be suitable. See** `Suggested Applications`_ **bel
            properties unambiguous. However, these terms are unrelated to the
            proportional size distributions and orientational distributions used in
            SasView models.
+
+Calculation of I(q)
+^^^^^^^^^^^^^^^^^^^
+
+Let $w(r)$ be the *relative number* of particles of size $r$, **not the volume
+fraction of particles**. $w(r)$ scales with the number density, $n(r)$.
+
+The *volume fraction*, $φ$, is the integrated volume of all particles, $V_p$, divided
+by total volume, $V_t$
+
+.. math:: 
+     :label: eq1
+
+     φ = \frac{V_p}{V_t}
+
+where $V_p$ is the number of particles, $N$, multiplied by the average particle volume
+$\langle V(r) \rangle$
+
+.. math::
+     :label: eq2
+
+     Vp = N \langle V(r) \rangle
+
+The *number density* of particles, $n$, is the total number of particles divided by
+the total volume
+
+.. math::
+     :label: eq3
+
+     n = \frac{N}{V_t}
+
+Since $w(r)$ is a distribution on the number of particles that (ideally) sums to one,
+the number of particles of size $r$, $n(r)$, scales with $w(r)$ as
+
+.. math::
+     :label: eq4
+
+     n(r) = \frac{w(r)}{∫w(r)dr} \cdot \frac{N}{V_t}
+
+Rewriting :eq:`eq1` as $V_p =  φ V_t$ and substituting into :eq:`eq2` gives
+$φ V_t = N \langle V(r) \rangle$ which can then be solved for $N / V_t$
+
+.. math::
+     :label: eq5
+
+     \frac{N}{V_t} = \frac{φ}{\langle V(r) \rangle}
+
+Substituting :eq:`eq5` into :eq:`eq4`, we get
+
+.. math::
+     :label: eq6
+
+     n(r) = \frac{w(r)}{∫w(r)dr} \cdot \frac{φ}{\langle V(r) \rangle}
+
+Since $w(r)$ is the relative number of particles of size $r$, the average volume is
+
+.. math::
+     :label: eq7
+
+     \langle V(r) \rangle = \frac{∫ w(r)V(r)dr}{∫ w(r)dr}
+
+Substituting :eq:`eq7` into :eq:`eq6` then yields
+
+.. math::
+     :label: eq8
+
+     n(r) = w(r) \cdot  \frac{φ}{∫ w(r)V(r)dr}
+
+Note that the second half of :eq:`eq8` is independent of $r$ and can slip out of the
+integral, such that
+
+.. math::
+     :label: eq9
+
+     I(q) = ∫ n(r) \langle F F^* \rangle dr
+          = φ  ∫ w(r) \langle F F^* \rangle dr /  ∫ w(r)V(r) dr
 
 Suggested Applications
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -533,6 +609,21 @@ T Allen, in *Particle Size Measurement*, 4th Edition, Chapman & Hall, London (19
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
+Related sections
+^^^^^^^^^^^^^^^^
+
+See also:
+
+:ref:`PStheory`
+
+:ref:`Resolution_Smearing`
+
+:ref:`Interaction_Models`
+
+:ref:`orientation`
+
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
 *Document History*
 
 | 2015-05-01 Steve King
@@ -541,3 +632,4 @@ T Allen, in *Particle Size Measurement*, 4th Edition, Chapman & Hall, London (19
 | 2018-04-04 Steve King
 | 2018-08-09 Steve King
 | 2021-11-03 Steve King
+| 2022-10-30 Steve King

--- a/doc/guide/pd/polydispersity.rst
+++ b/doc/guide/pd/polydispersity.rst
@@ -92,13 +92,13 @@ Calculation of I(q)
 Let $w(r)$ be the *relative number* of particles of size $r$, **not the volume
 fraction of particles**. $w(r)$ scales with the number density, $n(r)$.
 
-The *volume fraction*, $φ$, is the integrated volume of all particles, $V_p$, divided
-by total volume, $V_t$
+The *volume fraction*, $\phi$, is the integrated volume of all particles, $V_p$,
+divided by total volume, $V_t$
 
 .. math:: 
      :label: eq1
 
-     φ = \frac{V_p}{V_t}
+     \phi = \frac{V_p}{V_t}
 
 where $V_p$ is the number of particles, $N$, multiplied by the average particle volume
 $\langle V(r) \rangle$
@@ -122,36 +122,36 @@ the number of particles of size $r$, $n(r)$, scales with $w(r)$ as
 .. math::
      :label: eq4
 
-     n(r) = \frac{w(r)}{∫w(r)dr} \cdot \frac{N}{V_t}
+     n(r) = \frac{w(r)}{\int w(r)dr} \cdot \frac{N}{V_t}
 
-Rewriting :eq:`eq1` as $V_p =  φ V_t$ and substituting into :eq:`eq2` gives
-$φ V_t = N \langle V(r) \rangle$ which can then be solved for $N / V_t$
+Rewriting :eq:`eq1` as $V_p =  \phi V_t$ and substituting into :eq:`eq2` gives
+$\phi V_t = N \langle V(r) \rangle$ which can then be solved for $N / V_t$
 
 .. math::
      :label: eq5
 
-     \frac{N}{V_t} = \frac{φ}{\langle V(r) \rangle}
+     \frac{N}{V_t} = \frac{\phi}{\langle V(r) \rangle}
 
 Substituting :eq:`eq5` into :eq:`eq4`, we get
 
 .. math::
      :label: eq6
 
-     n(r) = \frac{w(r)}{∫w(r)dr} \cdot \frac{φ}{\langle V(r) \rangle}
+     n(r) = \frac{w(r)}{\int w(r)dr} \cdot \frac{\phi}{\langle V(r) \rangle}
 
 Since $w(r)$ is the relative number of particles of size $r$, the average volume is
 
 .. math::
      :label: eq7
 
-     \langle V(r) \rangle = \frac{∫ w(r)V(r)dr}{∫ w(r)dr}
+     \langle V(r) \rangle = \frac{\int w(r)V(r)dr}{\int w(r)dr}
 
 Substituting :eq:`eq7` into :eq:`eq6` then yields
 
 .. math::
      :label: eq8
 
-     n(r) = w(r) \cdot  \frac{φ}{∫ w(r)V(r)dr}
+     n(r) = w(r) \cdot  \frac{\phi}{\int w(r)V(r)dr}
 
 Note that the second half of :eq:`eq8` is independent of $r$ and can slip out of the
 integral, such that
@@ -159,8 +159,8 @@ integral, such that
 .. math::
      :label: eq9
 
-     I(q) = ∫ n(r) \langle F F^* \rangle dr
-          = φ  ∫ w(r) \langle F F^* \rangle dr /  ∫ w(r)V(r) dr
+     I(q) = \int n(r) \langle F F^* \rangle dr
+          = \frac{\phi \int w(r) \langle F F^* \rangle dr}{\int w(r)V(r) dr}
 
 Suggested Applications
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/guide/resolution.rst
+++ b/doc/guide/resolution.rst
@@ -6,8 +6,10 @@
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
-Resolution Functions
-====================
+.. _Resolution_Smearing:
+
+Resolution (Smearing) Functions
+===============================
 
 Sometimes the instrumental geometry used to acquire the experimental data has
 an impact on the clarity of features in the reduced scattering curve. For
@@ -302,10 +304,23 @@ data points for a given model and slit/pinhole size. The *Norm* factor is
 found numerically with the weighting matrix and applied on the computation
 of $I_s$.
 
+Related sections
+----------------
+
+See also:
+
+:ref:`PStheory`
+
+:ref:`polydispersityhelp`
+
+:ref:`Interaction_Models`
+
+:ref:`orientation`
+
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
 *Document History*
 
 | 2015-05-01 Steve King
 | 2017-05-08 Paul Kienzle
-| 2021-10-29 Steve King
+| 2022-10-30 Steve King

--- a/doc/guide/theory.rst
+++ b/doc/guide/theory.rst
@@ -1,0 +1,169 @@
+.. theory.rst
+
+.. Much of the following text was scraped from fitting_sq.py
+
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
+.. _PStheory:
+
+Theory
+======
+
+Scattering at vector $\mathbf Q$ for an individual particle with
+shape parameters $\mathbf\xi$ and contrast $\rho_c(\mathbf r, \mathbf\xi)$
+is computed from the square of the amplitude, $F(\mathbf Q, \mathbf\xi)$, as
+
+.. math::
+    I(\mathbf Q) = F(\mathbf Q, \mathbf\xi) F^*(\mathbf Q, \mathbf\xi)
+        \big/ V(\mathbf\xi)
+
+with the particle volume $V(\mathbf \xi)$ and
+
+.. math::
+    F(\mathbf Q, \mathbf\xi) = \int_{\mathbb R^3} \rho_c(\mathbf r, \mathbf\xi)
+        e^{i \mathbf Q \cdot \mathbf r} \,\mathrm d \mathbf r = F
+
+The 1-D scattering pattern for monodisperse particles uses the orientation
+average in spherical coordinates,
+
+.. math::
+    I(Q) = n \langle F F^*\rangle = \frac{n}{4\pi}
+    \int_{\theta=0}^{\pi} \int_{\phi=0}^{2\pi}
+    F F^* \sin(\theta) \,\mathrm d\phi \mathrm d\theta
+
+where $F(\mathbf Q,\mathbf\xi)$ uses
+$\mathbf Q = [Q \sin\theta\cos\phi, Q \sin\theta\sin\phi, Q \cos\theta]^T$.
+A $u$-substitution may be used, with $\alpha = \cos \theta$,
+$\surd(1 - \alpha^2) = \sin \theta$, and
+$\mathrm d\alpha = -\sin\theta\,\mathrm d\theta$.
+Here,
+
+.. math:: n = V_f/V(\mathbf\xi)
+
+is the number density of scatterers estimated from the volume fraction $V_f$
+of particles in solution. In this formalism, each incoming
+wave interacts with exactly one particle before being scattered into the
+detector. All interference effects are within the particle itself.
+The detector accumulates counts in proportion to the relative probability
+at each pixel. The extension to heterogeneous systems is simply a matter of
+adding the scattering patterns in proportion to the number density of each
+particle. That is, given shape parameters $\mathbf\xi$ with probability
+$P_\mathbf{\xi}$,
+
+.. math::
+
+    I(Q) = \int_\Xi n(\mathbf\xi) \langle F F^* \rangle \,\mathrm d\xi
+         = V_f\frac{\int_\Xi P_\mathbf{\xi} \langle F F^* \rangle
+         \,\mathrm d\mathbf\xi}{\int_\Xi P_\mathbf\xi V(\mathbf\xi)\,\mathrm d\mathbf\xi}
+
+This approximation is valid in the dilute limit, where particles are
+sufficiently far apart that the interaction between them can be ignored.
+
+As concentration increases, a structure factor term $S(Q)$ can be included,
+giving the monodisperse approximation for the interaction between particles,
+with
+
+.. math:: I(Q) = n \langle F F^* \rangle S(Q)
+
+For particles without spherical symmetry, the decoupling approximation
+is more accurate, with
+
+.. math::
+
+    I(Q) = n [\langle F F^* \rangle
+        + \langle F \rangle \langle F \rangle^* (S(Q) - 1)]
+
+Or equivalently,
+
+.. math:: I(Q) = P(Q)[1 + \beta\,(S(Q) - 1)]
+
+with the form factor $P(Q) = n \langle F F^* \rangle$ and
+$\beta = \langle F \rangle \langle F \rangle^* \big/ \langle F F^* \rangle$.
+These approximations can be extended to heterogeneous systems using averages
+over size, $\langle \cdot \rangle_\mathbf\xi = \int_\Xi P_\mathbf\xi \langle\cdot\rangle\,\mathrm d\mathbf\xi \big/ \int_\Xi P_\mathbf\xi \,\mathrm d\mathbf\xi$ and setting
+$n = V_f\big/\langle V \rangle_\mathbf\xi$.
+
+Further improvements can be made using the local monodisperse
+approximation (LMA) or using partial structure factors as done in [#bressler]_,
+but these are not implemented in this code.
+
+For hollow shapes, *volfraction* is computed from the material in the
+shell rather than the shell plus solvent inside the shell.  Using
+$V_e(\mathbf\xi)$ as the enclosed volume of the shell plus solvent and
+$V_c(\mathbf\xi)$ as the core volume of solvent inside the shell, we
+can compute the average enclosed and shell volumes as
+
+.. math::
+    :nowrap:
+
+    \begin{align*}
+    \langle V_e \rangle &= \frac{
+        \int_\Xi P_\mathbf\xi V_e(\mathbf\xi)\,\mathrm d\mathbf\xi
+    }{ \int_\Xi P_\mathbf\xi\,\mathrm d\mathbf \xi } \\
+    \langle V_s \rangle &= \frac{
+        \int_\Xi P_\mathbf\xi (V_e(\mathbf\xi) - V_c(\mathbf\xi))\,\mathrm d\mathbf\xi
+    }{ \int_\Xi P_\mathbf\xi\,\mathrm d\mathbf \xi }
+    \end{align*}
+
+Given $n$ particles and a total solvent volume $V_\text{out}$ outside the
+shells, the volume fraction of the shell, $\phi_s$ and the shell plus
+enclosed solvent $\phi_e$ are
+
+.. math::
+    :nowrap:
+
+    \begin{align*}
+    \phi_s &= \frac{n \langle V_s \rangle}{n \langle V_s \rangle + n \langle V_c \rangle + V_\text{out}}
+           = \frac{n \langle V_s \rangle}{V_\text{total}} \\
+    \phi_e &= \frac{n \langle V_e \rangle}{n \langle V_e \rangle + V_\text{out}}
+           = \frac{n \langle V_e \rangle}{V_\text{total}}
+    \end{align*}
+
+Dividing gives
+
+.. math::
+
+    \frac{\phi_S}{\phi_P} = \frac{\langle V_e \rangle}{\langle V_s \rangle}
+
+so the enclosed volume fraction can be computed from the shell volume fraction
+and the form:shell volume ratio as
+
+.. math::
+
+    \phi_S = \phi_P \langle V_e \rangle \big/ \langle V_s \rangle
+
+.. note::
+
+    Prior to Sasmodels v1.0.5 (Nov 2020), the intermediate $P(Q)$ returned by
+    the interaction calculator did not incorporate the volume normalization and
+    so $I(Q) \ne P(Q) S(Q)$. This became apparent when $P(Q)$ and $I(Q)$ were
+    plotted together. Further details can be found `here <https://github.com/SasView/sasview/issues/1698>`_.
+
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
+Related sections
+^^^^^^^^^^^^^^^^
+
+The concepts described above are developed further in the following sections:
+
+:ref:`polydispersityhelp`
+
+:ref:`Resolution_Smearing`
+
+:ref:`Interaction_Models`
+
+:ref:`orientation`
+
+References
+^^^^^^^^^^
+
+.. [#bressler] Bressler I., Kohlbrecher J., Thunemann A.F.
+   *J. Appl. Crystallogr.* 48 (2015) 1587-1598
+
+.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
+*Document History*
+
+| 2019-03-31 Paul Kienzle, Steve King & Richard Heenan
+| 2021-11-03 Steve King
+| 2022-10-29 Steve King


### PR DESCRIPTION
This PR addresses all the comments in:

- https://github.com/SasView/sasmodels/issues/397
- https://github.com/SasView/sasmodels/issues/387
- https://github.com/SasView/sasmodels/issues/205#issuecomment-603207732

It also resequences the Contents into what I think is a more logical order?