### PR TITLE
Effective radius does not have polydispersity.

### DIFF
--- a/sasmodels/models/hardsphere.py
+++ b/sasmodels/models/hardsphere.py
@@ -102,7 +102,7 @@ def random():
 # assuming double precision sasview is correct
 tests = [
     [{'scale': 1.0, 'background' : 0.0, 'radius_effective' : 50.0,
-      'volfraction' : 0.2, 'radius_effective_pd' : 0},
+      'volfraction' : 0.2},
      [0.001, 0.1], [0.209128, 0.930587]],
 ]
 # ADDED by: RKH  ON: 16Mar2016  using equations from FISH as better than


### PR DESCRIPTION
`radius_effective` is not tagged as a "volume" parameter, so doesn't allow polydispersity parameters.

A future patch is checking that the parameters to the model are valid and so the test will fail if we provide a value for the polydispersity.