### PR TITLE
Re-disable buggy check

### DIFF
--- a/sasmodels/direct_model.py
+++ b/sasmodels/direct_model.py
@@ -122,8 +122,9 @@ def get_mesh(model_info, values, dim='1d', mono=False):
     mesh = [_pop_par_weights(p, values, active(p.name))
             for p in parameters.call_parameters]
 
-    if values:
-        raise TypeError(f"Unused parameters in call: {', '.join(values.keys())}")
+    # This check is still causing errors, something deeper is going on, disable for now
+    # if values:
+    #     raise TypeError(f"Unused parameters in call: {', '.join(values.keys())}")
 
     return mesh
 


### PR DESCRIPTION
Previous attempts to unbug the orientation viewer didn't work out, this re-disables the breaking check until the right solution can be found.