### PR TITLE
Sasmodels doc build artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
-        tar zcf sasmodels-docs.tar.gz html
+        tar zcf sasmodels-docs.tar.gz _build/html
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,5 +67,5 @@ jobs:
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
-          sasmodels_docs.tar.gz
+          sasmodels/sasmodels_docs.tar.gz
         if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
         tar zcf sasmodels-docs.tar.gz doc/_build/html
+        pwd
         ls -l sasmodels-docs.tar.gz
 
     - name: Publish samodels docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,13 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
+        tar zcf sasmodels-docs.tar.gz html
 
     - name: Publish samodels docs
-      if: ${{ matrix.installer }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: actions/upload-artifact@v3
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
-          docs/html
+          sasmodels_docs.tar.gz
         if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,12 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
+
+    - name: Publish samodels docs
+      if: ${{ matrix.installer }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
+        path: |
+          docs/html
+        if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
-        tar zcf sasmodels-docs.tar.gz _build/html
+        tar zcf sasmodels-docs.tar.gz doc/_build/html
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         tar zcf sasmodels-docs.tar.gz doc/_build/html
 
     - name: Publish samodels docs
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'}}
       uses: actions/upload-artifact@v3
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,6 @@ jobs:
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
         tar zcf sasmodels-docs.tar.gz doc/_build/html
-        pwd
-        ls -l sasmodels-docs.tar.gz
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -69,5 +67,5 @@ jobs:
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
-          sasmodels/sasmodels/sasmodels_docs.tar.gz
+          sasmodels-docs.tar.gz
         if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
         tar zcf sasmodels-docs.tar.gz doc/_build/html
+        ls -l sasmodels-docs.tar.gz
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -67,5 +68,5 @@ jobs:
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
-          sasmodels/sasmodels_docs.tar.gz
+          sasmodels/sasmodels/sasmodels_docs.tar.gz
         if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
-        tar zcf sasmodels-docs.tar.gz doc/_build/html
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'}}
@@ -67,5 +66,5 @@ jobs:
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
-          sasmodels-docs.tar.gz
+          doc/_build/html
         if-no-files-found: error


### PR DESCRIPTION
Sasmodels docs have been already generated as a part of testing (in CI), however they were not stored. This PR allows storing html docs as a GH artifact. 