### PR TITLE
Release 1.0.8: Final requirements for sasmodels v1.0.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,6 @@ jobs:
     - name: Free Disk Space (Ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: jlumbroso/free-disk-space@main
-      with:
-        # this might remove tools that are actually needed,
-        # when set to "true" but frees about 6 GB
-        tool-cache: true
 
     - name: setup apt dependencies for Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -69,7 +65,7 @@ jobs:
     - name: check that the docs build (linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        -make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
+        make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,9 +69,7 @@ jobs:
     - name: check that the docs build (linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        sudo apt install make
-        sudo apt install echo
-        make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
+        -make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,11 @@ jobs:
     - name: setup apt dependencies for Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        sudo apt-get update
-        sudo apt-get install opencl-headers ocl-icd-opencl-dev libpocl2
+        wget https://repo.radeon.com/amdgpu-install/6.1.1/ubuntu/jammy/amdgpu-install_6.1.60101-1_all.deb
+        sudo apt install ./amdgpu-install_6.1.60101-1_all.deb
+        sudo apt update
+        sudo apt install amdgpu-dkms
+        sudo apt install rocm
 
     - name: Install Python dependencies
       run: |
@@ -35,7 +38,7 @@ jobs:
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
-        python -m pip install pyopencl==2023.1.4
+        python -m pip install pyopencl
 
     - name: setup pyopencl on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [windows-latest] # macos-latest, ubuntu-latest,
         python-version: ["3.10", "3.11"]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,20 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # when set to "true" but frees about 6 GB
+        tool-cache: true
 
     - name: setup apt dependencies for Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         python -m pip install pytools mako cffi
 
         choco install opencl-intel-cpu-runtime
-        python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl==2024.1
+        python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl
 
     - name: Test with pytest
       env:
@@ -69,6 +69,8 @@ jobs:
     - name: check that the docs build (linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
+        sudo apt install make
+        sudo apt install echo
         make -j 4 -C doc SPHINXOPTS="-W --keep-going -n" html
 
     - name: Publish samodels docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest] # macos-latest, ubuntu-latest,
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11"]
 
     steps:
@@ -35,7 +35,7 @@ jobs:
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
-        python -m pip install pyopencl==2024.1
+        python -m pip install pyopencl==2023.1.4
 
     - name: setup pyopencl on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
-        python -m pip install pyopencl
+        python -m pip install pyopencl==2024.1
 
     - name: setup pyopencl on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -43,7 +43,7 @@ jobs:
         python -m pip install pytools mako cffi
 
         choco install opencl-intel-cpu-runtime
-        python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl
+        python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl==2024.1
 
     - name: Test with pytest
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Free Disk Space (Ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: jlumbroso/free-disk-space@main
+      with:
+        haskell: false
+        large-packages: false
 
     - name: setup apt dependencies for Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,7 @@ import sasmodels
 
 nitpick_ignore = [
     ('py:class', 'argparse.Namespace'),
+    ('py:class', 'bumps.parameter.Parameter'),
     ('py:class', 'collections.OrderedDict'),
     ('py:class', 'cuda.Context'),
     ('py:class', 'cuda.Function'),
@@ -56,6 +57,7 @@ nitpick_ignore = [
     ('py:class', 'module'),
     ('py:class', 'SesansData'),
     ('py:class', 'SourceModule'),
+    ('py:class', 'TestCondition'),
     # KernelModel and Calculator breaking on git actions tests, even though
     # KernelModel is already listed. astropy example sometimes includes full
     # path to complaining symbol. Let's see if that helps here:
@@ -141,40 +143,6 @@ pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
-
-nitpick_ignore = [
-    ('py:class', 'argparse.Namespace'),
-    ('py:class', 'bumps.parameter.Parameter'),
-    ('py:class', 'collections.OrderedDict'),
-    ('py:class', 'cuda.Context'),
-    ('py:class', 'cuda.Function'),
-    ('py:class', 'np.dtype'),
-    ('py:class', 'numpy.dtype'),
-    ('py:class', 'np.ndarray'),
-    ('py:class', 'numpy.ndarray'),
-    ('py:class', 'pyopencl.Program'),
-    ('py:class', 'pyopencl._cl.Context'),
-    ('py:class', 'pyopencl._cl.CommandQueue'),
-    ('py:class', 'pyopencl._cl.Device'),
-    ('py:class', 'pyopencl._cl.Kernel'),
-    ('py:class', 'QWebView'),
-    ('py:class', 'unittest.suite.TestSuite'),
-    ('py:class', 'wx.Frame'),
-    # autodoc and namedtuple is completely broken
-    ('py:class', 'integer -- return number of occurrences of value'),
-    ('py:class', 'integer -- return first index of value.'),
-    # autodoc doesn't handle these type definitions
-    ('py:class', 'Data'),
-    ('py:class', 'Data1D'),
-    ('py:class', 'Data2D'),
-    ('py:class', 'Kernel'),
-    ('py:class', 'ModelInfo'),
-    ('py:class', 'module'),
-    ('py:class', 'SesansData'),
-    ('py:class', 'SourceModule'),
-    ('py:class', 'TestCondition'),
-]
-
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,7 @@ nitpick_ignore = [
     ('py:class', 'pyopencl._cl.Device'),
     ('py:class', 'pyopencl._cl.Kernel'),
     ('py:class', 'QWebView'),
+    ('py:class', 'types.ModuleType'),
     ('py:class', 'unittest.suite.TestSuite'),
     ('py:class', 'wx.Frame'),
     # autodoc and namedtuple is completely broken


### PR DESCRIPTION
This PR does the following:

- Removes build support for py 3.7, 3.8 and 3.9 (no longer supported on MacOS)
- Adds build support for py 3.11
- Increments action versions for `setup-python` and `checkout` to eliminate build warnings
- Uses AMD acceleration tools in Ubuntu instead of intel to fix pyopencl errors
- Combines 2 `nitpick_ignore` lists in `doc/conf.py` so modifications to first list aren't ignored

Fixes #595