### PR TITLE
Pin numpy to less than v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
         python -m pip install mako
-        python -m pip install numpy scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc
+        python -m pip install numpy<2 scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc
 
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def find_version(package):
                 return version[1:-1]
     raise RuntimeError("Could not read version from %s/__init__.py"%package)
 
-install_requires = ['numpy', 'scipy']
+install_requires = ['numpy<2', 'scipy']
 
 with open('README.rst') as fid:
     long_description = fid.read()


### PR DESCRIPTION
This pins the numpy version to any version less than 2 for the release branch.