### PR TITLE
Use numpy>=2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
         python -m pip install mako
-        python -m pip install numpy==1.*
-        python -m pip install scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc siphash24
+        python -m pip install numpy scipy matplotlib docutils pytest sphinx bumps==0.* unittest-xml-reporting tinycc siphash24
 
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install wheel setuptools
         python -m pip install mako
         python -m pip install numpy==1.*
-        python -m pip install scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc
+        python -m pip install scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc siphash
 
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install wheel setuptools
         python -m pip install mako
         python -m pip install numpy==1.*
-        python -m pip install scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc siphash
+        python -m pip install scipy matplotlib docutils pytest sphinx bumps unittest-xml-reporting tinycc siphash24
 
     - name: setup pyopencl on Linux + macOS
       if: ${{ matrix.os != 'windows-latest' }}

--- a/doc/guide/plugin.rst
+++ b/doc/guide/plugin.rst
@@ -568,7 +568,7 @@ value at a time::
 
     Iq.vectorized = False
 
-Return np.NaN if the parameters are not valid (e.g., cap_radius < radius in
+Return np.nan if the parameters are not valid (e.g., cap_radius < radius in
 barbell).  If I(q; pars) is NaN for any $q$, then those parameters will be
 ignored, and not included in the calculation of the weighted polydispersity.
 

--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -549,7 +549,7 @@ if 0 and USE_CUDA:
             if new_size > old_size:
                 new = np.empty(new_size, dtype=old.dtype)
                 new[:old_size] = old
-                new[old_size:] = np.NaN
+                new[old_size:] = np.nan
                 yield new
             else:
                 yield old
@@ -1115,7 +1115,7 @@ def _sasmodels_Iqxy(kernel, qx, qy, pars, view):
     # calculator avoids masked values; instead set masked values to NaN
     result = np.empty_like(qx)
     result[calculator.index] = Iqxy
-    result[~calculator.index] = np.NaN
+    result[~calculator.index] = np.nan
     return result
 
 def wrap_sasmodel(name, **pars):

--- a/sasmodels/compare_many.py
+++ b/sasmodels/compare_many.py
@@ -142,9 +142,9 @@ def compare_instance(name, data, index, N=1, mono=True, cutoff=1e-5,
             traceback.print_exc()
             print("when comparing %s for %d"%(name, seed))
             if hasattr(data, 'qx_data'):
-                result = np.NaN*data.data
+                result = np.nan*data.data
             else:
-                result = np.NaN*data.x
+                result = np.nan*data.x
         return result
     def check_model(pars):
         """
@@ -165,7 +165,7 @@ def compare_instance(name, data, index, N=1, mono=True, cutoff=1e-5,
     except Exception as exc:
         #raise
         print('"Error: %s"'%str(exc).replace('"', "'"))
-        print('"good","%d of %d","max diff",%g' % (0, N, np.NaN))
+        print('"good","%d of %d","max diff",%g' % (0, N, np.nan))
         return
     expected = max(PRECISION[base], PRECISION[comp])
 

--- a/sasmodels/data.py
+++ b/sasmodels/data.py
@@ -170,8 +170,8 @@ class Data1D(object):
         self.y, self.dy = _as_numpy(y), _as_numpy(dy)
         self.dxl = None
         self.filename = None
-        self.qmin = self.x.min() if self.x is not None else np.NaN
-        self.qmax = self.x.max() if self.x is not None else np.NaN
+        self.qmin = self.x.min() if self.x is not None else np.nan
+        self.qmax = self.x.max() if self.x is not None else np.nan
         # TODO: why is 1D mask False and 2D mask True?
         self.mask = (np.isnan(y) if y is not None
                      else np.zeros_like(x, 'b') if x is not None
@@ -314,7 +314,7 @@ class Source(object):
     """
     def __init__(self):
         # type: () -> None
-        self.wavelength = np.NaN
+        self.wavelength = np.nan
         self.wavelength_unit = "A"
 
 class Sample(object):

--- a/sasmodels/kernelpy.py
+++ b/sasmodels/kernelpy.py
@@ -235,8 +235,8 @@ def _loops(parameters, form, form_volume, form_radius, nq, call_details,
         weighted_form = 0.0
         weighted_shell = 0.0
         weighted_radius = 0.0
-        partial_weight = np.NaN
-        weight = np.NaN
+        partial_weight = np.nan
+        weight = np.nan
 
         p0_par = call_details.pd_par[0]
         p0_length = call_details.pd_length[0]

--- a/sasmodels/modelinfo.py
+++ b/sasmodels/modelinfo.py
@@ -79,7 +79,7 @@ def make_parameter_table(pars):
     partable.check_angles(strict=True)
     return partable
 
-def parse_parameter(name, units='', default=np.NaN,
+def parse_parameter(name, units='', default=np.nan,
                     user_limits=None, ptype='', description=''):
     # type: (str, str, float, Sequence[Any], str, str) -> Parameter
     """
@@ -320,7 +320,7 @@ class Parameter(object):
     parameter table is built using :func:`make_parameter_table` and
     :func:`parse_parameter` therein.
     """
-    def __init__(self, name, units='', default=np.NaN, limits=(-np.inf, np.inf),
+    def __init__(self, name, units='', default=np.nan, limits=(-np.inf, np.inf),
                  ptype='', description=''):
         # type: (str, str, float, Limits, str, str) -> None
         self.id = name.split('[')[0].strip() # type: str

--- a/sasmodels/models/__init__.py
+++ b/sasmodels/models/__init__.py
@@ -94,4 +94,5 @@ Other models:
     :mod:`teubner_strey`
     :mod:`two_lorentzian`
     :mod:`unified_power_Rg`
+
 """

--- a/sasmodels/models/spherical_sld.py
+++ b/sasmodels/models/spherical_sld.py
@@ -133,7 +133,7 @@ Erf:
     \end{cases}
 
 
-Boucher[#Boucher1983]_:
+Boucher [#Boucher1983]_:
 
 .. math::
 

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -476,9 +476,9 @@ class SasviewModel(object):
             if p.id == self.multiplicity_info.control:
                 value = float(self.multiplicity)
             elif p.length == 1:
-                value = self.params.get(p.id, np.NaN)
+                value = self.params.get(p.id, np.nan)
             else:
-                value = np.array([self.params.get(p.id+str(k), np.NaN)
+                value = np.array([self.params.get(p.id+str(k), np.nan)
                                   for k in range(1, p.length+1)])
             args[p.id] = value
 
@@ -841,7 +841,7 @@ class SasviewModel(object):
             else:
                 # For hidden parameters use default values.  This sets
                 # scale=1 and background=0 for structure factors
-                default = self._model_info.parameters.defaults.get(par.name, np.NaN)
+                default = self._model_info.parameters.defaults.get(par.name, np.nan)
                 return default, [default], [1.0]
         elif par.polydisperse:
             value = self.params[par.name]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     install_requires=install_requires,
     extras_require={
-        'full': ['docutils', 'bumps==0.*', 'matplotlib', 'columnize'],
+        'full': ['docutils', 'bumps==0.*', 'matplotlib', 'columnize', 'siphash24'],
         'server': ['bumps==0.*'],
         'OpenCL': ["pyopencl"],
         'CUDA': ["pycuda"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def find_version(package):
                 return version[1:-1]
     raise RuntimeError("Could not read version from %s/__init__.py"%package)
 
-install_requires = ['numpy==1.*', 'scipy']
+install_requires = ['numpy', 'scipy']
 
 with open('README.rst') as fid:
     long_description = fid.read()
@@ -70,8 +70,8 @@ setup(
     },
     install_requires=install_requires,
     extras_require={
-        'full': ['docutils', 'bumps', 'matplotlib', 'columnize'],
-        'server': ['bumps'],
+        'full': ['docutils', 'bumps==0.*', 'matplotlib', 'columnize'],
+        'server': ['bumps==0.*'],
         'OpenCL': ["pyopencl"],
         'CUDA': ["pycuda"],
     },


### PR DESCRIPTION
This allows sasmodels to use numpy>=2. This also fixes two sphinx warnings that were happening during the build.

Fixes #604 
Fixes #598 
Refs #609 