### PR TITLE
Improve stability of binary_hard_sphere for low q

### DIFF
--- a/sasmodels/models/binary_hard_sphere.c
+++ b/sasmodels/models/binary_hard_sphere.c
@@ -169,7 +169,7 @@ void calculate_psfs(double qval,
         ttt3=cos(yl)*(t31+t32+t33)/(y13*y1);
         ttt4=a1*(t41+t42)/y1;
     } else {
-        // [PAK] note that y1 = ay and yl = (1-a)/2 y = (1-a)/2a y1
+        // [PAK] note that y1 = ay and yl = (1-a)/2a y1 = (1-a)/2 y
         // [PAK] rewrite ttt2 as sin(yl)/y1 * (t21/y1^3 + t22/y1^3 + t23/y1^3)
         // [PAK] lim y->0 sin(yl)/y1 = sin((1-a)/2 y)/(ay) = (1-a)/(2a)
         // [PAK] lim y->0 t21 / y1^3 = b12/3

--- a/sasmodels/models/binary_hard_sphere.c
+++ b/sasmodels/models/binary_hard_sphere.c
@@ -169,14 +169,21 @@ void calculate_psfs(double qval,
         ttt3=cos(yl)*(t31+t32+t33)/(y13*y1);
         ttt4=a1*(t41+t42)/y1;
     } else {
-        // [PAK] lim y1=>0 t21 / y1^3 = b12/3
-        // [PAK] lim y1=>0 t22 / y1^3 = gm12/4
-        // [PAK] lim y1=>0 t23 / y1^3 = gm1/5
-        // [PAK] lim y1=>0 t31 / y1^4 = b12/4
-        // [PAK] lim y1=>0 t32 / y1^4 = gm12/5
-        // [PAK] lim y1=>0 t33 / y1^4 = gm1/6
-        // [PAK] lim y=>0 (t41 + t42)/y1 = 1/12 + 1/(4a^2)
-        // [PAK] lim y=>0 sin(yl)/y1 = sin(y(1-a)/2)/(ya) = (1/a - 1)/2
+        // [PAK] note that y1 = ay and yl = (1-a)/2 y = (1-a)/2a y1
+        // [PAK] rewrite ttt2 as sin(yl)/y1 * (t21/y1^3 + t22/y1^3 + t23/y1^3)
+        // [PAK] lim y->0 sin(yl)/y1 = sin((1-a)/2 y)/(ya) = (1/a - 1)/2
+        // [PAK] lim y->0 t21 / y1^3 = b12/3
+        // [PAK] lim y->0 t22 / y1^3 = gm12/4
+        // [PAK] lim y->0 t23 / y1^3 = gm1/5
+        // [PAK] rewrite ttt3 as cos(yl) * (t31/y1^4 + t32/y1^4 + t33/y1^4)
+        // [PAK] lim y->0 cos(yl) = 1
+        // [PAK] lim y->0 t31 / y1^4 = b12/4
+        // [PAK] lim y->0 t32 / y1^4 = gm12/5
+        // [PAK] lim y->0 t33 / y1^4 = gm1/6
+        // [PAK] rewrite ttt4 using A = (1-a)/2a and x = y1, so yl = Ax
+        // [PAK] lim x=>0 t41/x = cos(Ax) [ (sin x - x cos x)/x^3 + A (1 - cos x)/x^2] = 1/3 + A/2
+        // [PAK] lim x=>0 t42/x = sin(Ax)/x [(cos x + x sin x - 1)/x^2 + A sin(x)/x] = A (1/2 + A)
+        // [PAK] lim y=>0 (t41 + t42)/y1 = 1/3 + A + A^2 = 1/12 + 1/(4a^2)
         ttt2 = (1./aa - 1.)/2. * (b12/3. + gm12/4. + gm1/5.);
         ttt3 = b12/4. + gm12/5. + gm1/6.;
         ttt4 = a1 * (1./12. + 1./(4.*aa*aa));

--- a/sasmodels/models/binary_hard_sphere.c
+++ b/sasmodels/models/binary_hard_sphere.c
@@ -171,7 +171,7 @@ void calculate_psfs(double qval,
     } else {
         // [PAK] note that y1 = ay and yl = (1-a)/2 y = (1-a)/2a y1
         // [PAK] rewrite ttt2 as sin(yl)/y1 * (t21/y1^3 + t22/y1^3 + t23/y1^3)
-        // [PAK] lim y->0 sin(yl)/y1 = sin((1-a)/2 y)/(ya) = (1/a - 1)/2
+        // [PAK] lim y->0 sin(yl)/y1 = sin((1-a)/2 y)/(ay) = (1-a)/(2a)
         // [PAK] lim y->0 t21 / y1^3 = b12/3
         // [PAK] lim y->0 t22 / y1^3 = gm12/4
         // [PAK] lim y->0 t23 / y1^3 = gm1/5
@@ -180,11 +180,11 @@ void calculate_psfs(double qval,
         // [PAK] lim y->0 t31 / y1^4 = b12/4
         // [PAK] lim y->0 t32 / y1^4 = gm12/5
         // [PAK] lim y->0 t33 / y1^4 = gm1/6
-        // [PAK] rewrite ttt4 using A = (1-a)/2a and x = y1, so yl = Ax
-        // [PAK] lim x=>0 t41/x = cos(Ax) [ (sin x - x cos x)/x^3 + A (1 - cos x)/x^2] = 1/3 + A/2
-        // [PAK] lim x=>0 t42/x = sin(Ax)/x [(cos x + x sin x - 1)/x^2 + A sin(x)/x] = A (1/2 + A)
-        // [PAK] lim y=>0 (t41 + t42)/y1 = 1/3 + A + A^2 = 1/12 + 1/(4a^2)
-        ttt2 = (1./aa - 1.)/2. * (b12/3. + gm12/4. + gm1/5.);
+        // [PAK] rewrite ttt4 using A = (1-a)/(2a) and x = y1, so yl = Ax
+        // [PAK] lim y->0 t41/y1 = cos(Ax) [ (sin x - x cos x)/x^3 + A (1 - cos x)/x^2] = 1/3 + A/2
+        // [PAK] lim y->0 t42/y1 = sin(Ax)/x [(cos x + x sin x - 1)/x^2 + A sin(x)/x] = A (1/2 + A)
+        // [PAK] lim y->0 (t41 + t42)/y1 = 1/3 + A + A^2 = 1/12 + 1/(4a^2)
+        ttt2 = (1. - aa)/(2.*aa) * (b12/3. + gm12/4. + gm1/5.);
         ttt3 = b12/4. + gm12/5. + gm1/6.;
         ttt4 = a1 * (1./12. + 1./(4.*aa*aa));
     }


### PR DESCRIPTION
Sets binary hard sphere form factor to limit value for small q. This hides the numerical instability without fixing it.

I tested various large sphere radii (1000, 100, 10) and various sphere ratios (1:1.001, 1:4, 1:10, 1:100). There are still some places where the cutoff is too low (with noise showing up at low q) or too high (abrupt jump to the limit).

Please check that reasonable values of radii are supported, and record them in the model documentation. Also check a range of volume fractions.

Refs #306