### PR TITLE
Update version of upload-artifact version to latest so builds can run…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Publish samodels docs
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'}}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sasmodels-docs-${{ matrix.os }}-${{ matrix.python-version }}
         path: |


### PR DESCRIPTION
Version 3 of the upload-artifact action was deprecated on Januray 31, 2025. This increments the version to allow our CI to run

Supersedes #632 (extra commits in that branch)