### PR TITLE
Fix pickle errors with product models

### DIFF
--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -740,7 +740,7 @@ class SasviewModel(object):
                             magnetic=is_magnetic)
         lazy_results = getattr(calculator, 'results',
                                lambda: collections.OrderedDict())
-        #print("result", result)
+        #print("result", result, lazy_results())
 
         calculator.release()
         #self._model.release()


### PR DESCRIPTION
Bumps parallel fitting uses dill to pickle models and send them to another process.

Not sure if this is a recent change in dill, but it no longer pickles lambda expressions and locally defined functions.

Work around this by creating callable objects with the relevant variables rather than returning an unpickleable closure.

Tested as follows:
* use bumps in the sasmodels/example directory as follows: `bumps model_ellipsoid_hayter_msa.py 093191_201.dat --fit=dream --store=/tmp/T1`
* ran sascomp with randomization: `python -m sasmodels.compare sphere@hardsphere -sets=10`
* ran sasview and set up a model with `sphere@hardsphere` and the above data file, clicking calculate to make sure the results were populated with P(Q) and S(Q), and with β when the β approximation was requested.