### PR TITLE
Fix hayter msa random model

### DIFF
--- a/sasmodels/models/hayter_msa.py
+++ b/sasmodels/models/hayter_msa.py
@@ -133,12 +133,12 @@ def random():
         radius_effective=10**np.random.uniform(1, 4.7),
         volfraction=10**np.random.uniform(-2, 0),  # high volume fraction
         charge=min(int(10**np.random.uniform(0, 1.3)+0.5), 200),
-        temperature=10**np.random.uniform(0, np.log10(450)), # max T = 450
-        #concentration_salt=10**np.random.uniform(-3, 1),
-        dialectconst=10**np.random.uniform(0, 6),
+        temperature=np.random.uniform(270, 450), # max T = 450
+        concentration_salt=10**np.random.uniform(-3, 1),
+        dielectconst=10**np.random.uniform(0, 6),
         #charge=10,
         #temperature=318.16,
-        concentration_salt=0.0,
+        #concentration_salt=0.0,
         #dielectconst=71.08,
     )
     return pars

--- a/sasmodels/sasview_model.py
+++ b/sasmodels/sasview_model.py
@@ -740,7 +740,7 @@ class SasviewModel(object):
                             magnetic=is_magnetic)
         lazy_results = getattr(calculator, 'results',
                                lambda: collections.OrderedDict())
-        #print("result", result)
+        #print("result", result, lazy_results())
 
         calculator.release()
         #self._model.release()


### PR DESCRIPTION
Random Hayter MSA model generation was failing because of a typo in one of the parameter names. On further investigation I noticed that the salt concentration was not randomized, and the temperature range was too extreme.

Test using:
```sh
python -m sasmodels.compare hayter_msa -midq -pars -highq -sets=1
```

Many random models fail are failing (see #143). We should either address the instabilities in the calculation that lead to bad values, or limit the ranges on the parameters to exclude those values.