### PR TITLE
Use bumps v1+ for latest release

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,4 +1,4 @@
-bumps==0.*
+bumps>=1.0.0a0
 columnize
 matplotlib
 numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "hatch-requirements-txt",
   "hatch-sphinx",
   "hatch-vcs",
-  "bumps==0.*",
+  "bumps>=1.0.0a0",
   "docutils",
   "matplotlib",
   "columnize",


### PR DESCRIPTION
This allows a pip install of the latest bumps prerelease during the CI process.

Replaces #644 