### PR TITLE
Improve pyinstaller hook

### DIFF
--- a/sasmodels/__init__.py
+++ b/sasmodels/__init__.py
@@ -15,7 +15,7 @@ defining new models.
 """
 
 try:
-    from _version import __version__
+    from ._version import __version__
 except ImportError:
     __version__ = "0.0.0.dev"
 

--- a/sasmodels/__pyinstaller/hook-sasmodels.py
+++ b/sasmodels/__pyinstaller/hook-sasmodels.py
@@ -25,6 +25,7 @@ try:
         "sasmodels.multiscat",
         "sasmodels.special",
     ]
+    module_collection_mode = "py"
 
     print(f"sasmodels added hiddenimports: {hiddenimports}")
 

--- a/sasmodels/__pyinstaller/hook-sasmodels.py
+++ b/sasmodels/__pyinstaller/hook-sasmodels.py
@@ -18,6 +18,12 @@ try:
 
     hiddenimports = [
         "pyopencl",
+        "sasmodels.compare_many",
+        "sasmodels.guyou",
+        "sasmodels.jitter",
+        "sasmodels.list_pars",
+        "sasmodels.multiscat",
+        "sasmodels.special",
     ]
 
     print(f"sasmodels added hiddenimports: {hiddenimports}")


### PR DESCRIPTION
In looking at https://github.com/SasView/sasview/issues/3380, I found that:

 - there were a few python files within sasmodels that were never imported and so are missed by pyinstaller's analyse step
 - the import of `_version` needed to be relative in `__init__.py`

`sasmodels.special` is not imported from with sasmodels and so was never spotted by pyinstaller; adding it as a `hiddenimport` lets pyinstaller know that it is needed and will be missed. Looking at the other python files in the module, there are some others in the same boat, so this PR also adds them.

pyinstaller hooks can also specify that a module should be left unpacked on disk rather than compressed into the pyinstaller output — normally, the .py files would end up inside the executable and the data files would stay unpacked on disk. The sasmodels module has a lot of data files - as some risk mitigation about some of them being loaded in ways that pyinstaller will break, it seems worth leaving them unpacked. There's also a relatively high probability of someone wanting to look at the pyinstaller output and then get concerned that sasmodels seems to be missing. In the 5.x and 6.0.x sasview releases, sasmodels was included both inside the pyinstaller output executable **and** as unpacked files, so this gets us to a simpler state without duplicating quite so many files or leaving it in a confusing state as to which files were used.

The relative import change seems necessary... I didn't need it in my original testing but definitely do now, to prevent a "0.0.0.dev" version poking through.
