### PR TITLE
Include the architecture in the filename for compilation cache

### DIFF
--- a/sasmodels/kerneldll.py
+++ b/sasmodels/kerneldll.py
@@ -77,6 +77,7 @@ import tempfile
 import ctypes as ct  # type: ignore
 import _ctypes as _ct
 import logging
+import platform
 
 import numpy as np  # type: ignore
 
@@ -220,7 +221,8 @@ def dll_name(model_file, dtype):
     any path or extension, with a form such as 'sas_sphere32'.
     """
     bits = 8*dtype.itemsize
-    basename = "sas%d_%s"%(bits, model_file)
+    arch = platform.machine()
+    basename = "sas%d_%s_%s"%(bits, arch, model_file)
     basename += ARCH + ".so"
 
     # Hack to find precompiled dlls.


### PR DESCRIPTION
In https://github.com/SasView/sasview/issues/3430 it appears that two different architecture Python interpreters are on the same machine - loading a sasmodels compiled model that was produced by the wrong interpreter either leads to crashes or errors that the model is not available.

Given universal binaries, rosetta2 etc, there's a reasonable chance that this `arm64` vs `x86_64` - if that's the case, then `platform.machine()` is the route to differentiating them as it returns those strings under the two scenarios. I understand it should also differentiate similar multiarch situations on windows and linux. Including `platform.machine()` in the cached object filename to make the cache specific to the interpreter architecture does enough.

There's also a chance that these are interpreters both compiled for the same architecture but with incompatible compilers — I don't know if that is a consideration for macos - it certainly is for windows. 