### PR TITLE
Cache figures between CI builds to speed up runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,15 @@ jobs:
         path: ${{ env.SASMODELS_BUILD_CACHE }}
         key: ${{ steps.build-tools.outputs.details }}-${{ hashFiles('doc/genmodel.py') }}
 
+    - name: Report cache status
+      if: env.BUILD_WHEEL
+      run: |
+        if [ "${{ steps.cache-figures.outputs.cache-hit }}" == "true" ]; then
+          echo "Figure cache hit - using cached figures"
+        else
+          echo "Figure cache miss - will generate new figures"
+        fi
+
     - name: Build sasmodels
       if: env.BUILD_WHEEL
       run: |


### PR DESCRIPTION
This PR uses an additional cache action to store the figures, using sasmodels' existing ability to keep figures in a cache so they do not need to be continually rebuilt. As suggested in the code, the cache is invalidated if `doc/genmodel.py` is changed or if the matplotlib version is changed.

Caching the figures shaves about 70s of the CI, with the Windows runners now being the slowest to complete. The slowest step on that slowest path is installing the test dependencies; that could be sped up with `uv` if desired.

~~Marking as a draft for now since to get CI to run at all, ruff currently needs to be disabled.~~