### PR TITLE
Update Python versions in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     env:
-       BUILD_WHEEL: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12') && 'true' || '' }}
+       BUILD_WHEEL: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14') && 'true' || '' }}
 
     steps:
 


### PR DESCRIPTION
With Python 3.14 released, it's time to look at getting new versions into the test matrix.

This PR:

- [x] drops Python 3.10 which is very close to end of life (and likely EOL before the next sasmodels release)
- [x] adds Python 3.13 and the tests pass
- [x] adds Python 3.14

This PR is marked as a draft until...

- [x] ruff is fixed (and the first change in the PR can be dropped
- [x] adds Python 3.14 which currently fails, looking for a new pyopencl, which is to be expected (and maybe other packages)

We can periodically rerun this to see how progress towards 3.14 is going; we might do the top two items anyway at this stage.

EDIT: pyopencl wheels for 3.14 are now available and CI passes, so this is ready to be merged.