### PR TITLE
Add TwoYukawa to pyinstaller hiddenimports

### DIFF
--- a/sasmodels/__pyinstaller/hook-sasmodels.py
+++ b/sasmodels/__pyinstaller/hook-sasmodels.py
@@ -24,13 +24,7 @@ try:
         "sasmodels.list_pars",
         "sasmodels.multiscat",
         "sasmodels.special",
-        "sasmodels.TwoYukawa.__init__",
-        "sasmodels.TwoYukawa.CalcRealRoot",
-        "sasmodels.TwoYukawa.CalTYSk",
-        "sasmodels.TwoYukawa.Ecoefficient",
-        "sasmodels.TwoYukawa.Epoly",
-        "sasmodels.TwoYukawa.TFourier",
-        "sasmodels.TwoYukawa.TInvFourier",
+        "sasmodels.models.two_yukawa",
     ]
     module_collection_mode = "py"
 


### PR DESCRIPTION
The auxiliary files for the two yukawa model aren't making it into the pyinstaller bundles as they are neither imported somewhere nor listed as data files. The result is that the two yukawa model can't be imported by sasview at runtime and so crashes on startup (yes, sasview should probably figure out some protection against this too).

This PR adds the `sasmodels.TwoYukawa` modules to the list of `hiddenimports` so that pyinstaller inserts them into bundles when using them.

This will eventually solve https://github.com/SasView/sasview/issues/3664