### PR TITLE
bumps 1.1 source tree was rearranged

### DIFF
--- a/sasmodels/compare.py
+++ b/sasmodels/compare.py
@@ -1610,11 +1610,15 @@ def explore(opts):
 def webview_explore(problem):
     import logging
 
-    import bumps.webview.server.webserver as server
     from aiohttp import web
-    from bumps.webview.server import api
-    from bumps.webview.server.cli import BumpsOptions
-
+    try:
+        from bumps import api
+        from bumps.cli import BumpsOptions
+        from bumps.webview import webserver as server
+    except ImportError: # CRUFT: bumps 1.1 rearranged internal structure
+        from bumps.webview.server import api
+        from bumps.webview.server import webserver as server
+        from bumps.webview.server.cli import BumpsOptions
     logging.getLogger("webview").setLevel(logging.WARNING)
 
     server.init_web_app()
@@ -1665,7 +1669,10 @@ class Explore:
 
     def __init__(self, opts):
         # type: (Dict[str, Any]) -> None
-        from bumps.cli import config_matplotlib  # type: ignore
+        try:
+            from bumps.plotutil import config_matplotlib  # type: ignore
+        except ImportError: # CRUFT: bumps 1.1 rearranged internal structure
+            from bumps.cli import config_matplotlib
 
         from . import bumps_model
 


### PR DESCRIPTION
The bumps source tree is being reorganized for version 1.1, so some imports have moved to different locations.

This PR supports both the old and the new interfaces.

This only affects the `python -m sasmodels.compare -edit MODELNAME` invocation used to explore the parameter space of the model interactively.

Test that it works before and after using
```sh
uv pip install git+https://github.com/bumps/bumps.git@centralize-bumps-api-4
python -m sasmodels.compare -edit cylinder
uv pip install bumps==1.0.4
python -m sasmodels.compare -edit cylinder
```
