### PR TITLE
remove 'unused step' warnings from kernels without pd

### DIFF
--- a/sasmodels/kernel_iq.c
+++ b/sasmodels/kernel_iq.c
@@ -666,15 +666,14 @@ After expansion, the loop struction will look like the following:
 // ====== construct the loops =======
 
 // Pointers to the start of the dispersity and weight vectors, if needed.
-#if MAX_PD>0
-  pglobal const double *pd_value = values + NUM_VALUES;
-  pglobal const double *pd_weight = pd_value + details->num_weights;
-#endif
-
 // The variable "step" is the current position in the dispersity loop.
 // It will be incremented each time a new point in the mesh is accumulated,
 // and used to test whether we have reached pd_stop.
-int step = pd_start;
+#if MAX_PD>0
+  pglobal const double *pd_value = values + NUM_VALUES;
+  pglobal const double *pd_weight = pd_value + details->num_weights;
+  int step = pd_start;
+#endif
 
 // *** define loops for each of 0, 1, 2, ..., modelinfo.MAX_PD-1 ***
 
@@ -805,8 +804,8 @@ PD_OUTERMOST_WEIGHT(MAX_PD)
     }
   }
 // close nested loops
-++step;
 #if MAX_PD>0
+  ++step;
   PD_CLOSE(0)
 #endif
 #if MAX_PD>1


### PR DESCRIPTION
For models without polydispersity, the c compiler was returning warnings about an unused step parameter for every variant of the calculator (Iq, Iqxy, Imagnetic). This made it hard to see the actual error.

After the fix the following
```c
2026-06-01 21:49:10,725 : ERROR : sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor (TabbedModelEditor.py:466) :: Error building model: compile failed.
cc -std=c99 -O2 -Wall -fPIC -shared /tmp/sas64_arm64_yuk_29A943E8_egi_n035.c -o ".../SasView/compiled_models/sas64_arm64_yuk_29A943E8.so" -lm
.../SasView/plugin_models/yuk.py:65:5: error: use of undeclared identifier 'broken'
   65 |     broken;
      |     ^~~~~~
./kernel_iq.c Iq:677:5: warning: variable 'step' set but not used [-Wunused-but-set-variable]
  677 | int step = pd_start;
      |     ^
./kernel_iq.c Iqxy:677:5: warning: variable 'step' set but not used [-Wunused-but-set-variable]
  677 | int step = pd_start;
      |     ^
./kernel_iq.c Imagnetic:677:5: warning: variable 'step' set but not used [-Wunused-but-set-variable]
  677 | int step = pd_start;
      |     ^
3 warnings and 1 error generated.
```

becomes
```c
2026-06-01 21:53:07,905 : ERROR : sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor (TabbedModelEditor.py:466) :: Error building model: compile failed.
cc -std=c99 -O2 -Wall -fPIC -shared /tmp/sas64_arm64_yuk_756BDC0C_cb1sfuot.c -o ".../SasView/compiled_models/sas64_arm64_yuk_756BDC0C.so" -lm
.../SasView/plugin_models/yuk.py:65:5: error: use of undeclared identifier 'broken'
   65 |     broken;
      |     ^~~~~~
1 error generated.
```