### PR TITLE
Updates header comment in truncated_octahedron.py

### DIFF
--- a/sasmodels/models/truncated_octahedron.py
+++ b/sasmodels/models/truncated_octahedron.py
@@ -1,4 +1,4 @@
-# octahedron_truncated model
+# truncated_octahedron model
 # Note: model title and parameter table are inserted automatically
 r"""
 This model provides the form factor P(q) for a general octahedron.


### PR DESCRIPTION
In #725, the model `octahedron_truncated` was renamed to `truncated_octahedron`. This has led to some issues with existing SasModels & SasView builds, as set out in SasView/sasview#3993.

Whilst longer term solutions should be sought, I have updated the header comment for consistency here.