### PR TITLE
Replace np.trapz with np.trapezoid

### DIFF
--- a/explore/asymint.py
+++ b/explore/asymint.py
@@ -416,7 +416,7 @@ def gridded_2d(q, n=300):
     Zq *= abs(sin(Atheta))
     dx, dy = theta[1]-theta[0], phi[1]-phi[0]
     print("rect-%d"%n, n**2, np.sum(Zq)*dx*dy*SCALE/(4*pi))
-    print("trapz-%d"%n, n**2, np.trapz(np.trapz(Zq, dx=dx), dx=dy)*SCALE/(4*pi))
+    print("trapz-%d"%n, n**2, np.trapezoid(np.trapezoid(Zq, dx=dx), dx=dy)*SCALE/(4*pi))
     print("simpson-%d"%n, n**2, simps(simps(Zq, dx=dx), dx=dy)*SCALE/(4*pi))
     print("romb-%d"%n, n**2, romb(romb(Zq, dx=dx), dx=dy)*SCALE/(4*pi))
 

--- a/explore/realspace.py
+++ b/explore/realspace.py
@@ -920,7 +920,7 @@ def j0(x):
 
 def calc_Iq_from_Pr(q, r, Pr):
     Iq = np.array([simpson(Pr * j0(qk*r), x=r) for qk in q])
-    #Iq = np.array([np.trapz(Pr * j0(qk*r), r) for qk in q])
+    #Iq = np.array([np.trapezoid(Pr * j0(qk*r), r) for qk in q])
     #Iq /= Iq[0]
     return Iq
 

--- a/explore/symint.py
+++ b/explore/symint.py
@@ -78,7 +78,7 @@ def gridded_1d(q, n=300):
     Zq *= abs(sin(theta))
     dx = theta[1]-theta[0]
     print("rect-%d"%n, np.sum(Zq)*dx*SCALE)
-    print("trapz-%d"%n, np.trapz(Zq, dx=dx)*SCALE)
+    print("trapz-%d"%n, np.trapezoid(Zq, dx=dx)*SCALE)
     print("simpson-%d"%n, simps(Zq, dx=dx)*SCALE)
     print("romb-%d"%n, romb(Zq, dx=dx)*SCALE)
 

--- a/explore/symint.py
+++ b/explore/symint.py
@@ -107,16 +107,16 @@ def plot_1d(q, n=300):
     pylab.xlabel("theta (degrees)")
     pylab.ylabel("Iq 1/cm")
 
-def Iq_trapz(q, n):
+def Iq_trapezoid(q, n):
     theta = np.linspace(THETA_LOW, THETA_HIGH, n)
     Zq = kernel_1d(q=q, theta=theta)
     Zq *= abs(sin(theta))
     dx = theta[1]-theta[0]
-    return np.trapz(Zq, dx=dx)*SCALE
+    return np.trapezoid(Zq, dx=dx)*SCALE
 
 def plot_Iq(q, n, form="trapz"):
     if form == "trapz":
-        Iq = np.array([Iq_trapz(qk, n) for qk in q])
+        Iq = np.array([Iq_trapezoid(qk, n) for qk in q])
     elif form == "gauss":
         Iq = np.array([gauss_quad_1d(qk, n) for qk in q])
     pylab.loglog(q, Iq, label="%s, n=%d"%(form, n))

--- a/sasmodels/resolution.py
+++ b/sasmodels/resolution.py
@@ -618,7 +618,7 @@ def _quad_slit_1d(form, pars, q, *, q_width=0., q_length=0.):
             w_grid = np.linspace(-dw, dw, nw)[:, None]
             u_sub = sqrt((qi + w_grid)**2 + l_grid**2)
             f_at_u = np.interp(u_sub, q_calc, Iq)
-            #print(np.trapz(Iu, w_grid, axis=1))
+            #print(np.trapezoid(Iu, w_grid, axis=1))
             total = np.trapezoid(np.trapezoid(f_at_u, l_grid, axis=1), w_grid[:, 0])
             result[i] = total / (4*dl*dw)
             # from scipy.integrate import dblquad

--- a/sasmodels/resolution2d.py
+++ b/sasmodels/resolution2d.py
@@ -235,7 +235,7 @@ class Slit2D(Resolution):
             raise ValueError("Slit2D fails with q_calc != q")
 
     def apply(self, theory):
-        Iq = np.trapz(theory.reshape(self.ny, self.nx), axis=0, x=self.qy_calc)
+        Iq = np.trapezoid(theory.reshape(self.ny, self.nx), axis=0, x=self.qy_calc)
         if self.weights is not None:
             Iq = resolution.apply_resolution_matrix(self.weights, Iq)
         return Iq


### PR DESCRIPTION
np.trapz was removed in 2.4.0. The replacement, np.trapezoid, is in all currently supported versions of numpy, so we don't need to guard the import statements.

Most instances are in comments or exploratory code.

The only active code which uses trapezoid is in the Slit2D resolution function for oriented samples measured with slit geometry. This is only available when using sasmodels directly. SasView does not support USANS/USAXS measurements on oriented samples.