### PR TITLE
Make tccbox an optional dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
         python -m pip install build hatchling
         python -m build --sdist --wheel
         python -m pip install dist/sasmodels*whl
+        python -m pip check
+        python -c "from importlib.metadata import requires; req = [r for r in requires('sasmodels') if r.startswith('tccbox')]; assert len(req) == 1 and \"sys_platform == 'win32'\" in req[0] and \"extra == 'tinycc'\" in req[0], req"
+        python -c "import sasmodels.kerneldll"
 
     - name: Publish sdist and wheel package
       if: env.BUILD_WHEEL
@@ -122,6 +125,11 @@ jobs:
       run: |
         python -m pip install -r build_tools/requirements.txt -r build_tools/requirements-test.txt -r build_tools/requirements-opencl.txt
 
+    - name: Install optional TinyCC compiler (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        python -m pip install -r build_tools/requirements-tinycc.txt
+
     ### Build and test sasmodels
 
     - name: Test with pytest
@@ -130,4 +138,3 @@ jobs:
         SAS_OPENCL: none
       run: |
         pytest -v
-

--- a/build_tools/requirements-tinycc.txt
+++ b/build_tools/requirements-tinycc.txt
@@ -1,0 +1,1 @@
+tccbox; sys_platform == "win32"

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -4,4 +4,3 @@ matplotlib
 numpy
 scipy
 siphash24
-tccbox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires = [
   "scipy",
   "siphash24",
   "sphinx",
-  "tccbox",
 ]
 build-backend = "hatchling.build"
 
@@ -75,6 +74,7 @@ server = [ "build_tools/requirements-server.txt" ]
 OpenCL = [ "build_tools/requirements-opencl.txt" ]
 CUDA = [ "build_tools/requirements-cuda.txt" ]
 docs = [ "build_tools/requirements-docs.txt" ]
+tinycc = [ "build_tools/requirements-tinycc.txt" ]
 
 
 [tool.hatch.version]

--- a/sasmodels/kerneldll.py
+++ b/sasmodels/kerneldll.py
@@ -6,14 +6,14 @@ will attempt to compile with OpenMP flags so that the model can use all
 available kernels.  This may or may not be available on your compiler
 toolchain.  Depending on operating system and environment.
 
-Windows does not have provide a compiler with the operating system.
-Instead, we assume that TinyCC is installed and available.  This can
-be done with a simple pip command if it is not already available::
+Windows does not provide a compiler with the operating system. TinyCC support
+is available as an optional dependency and can be installed with::
 
-    pip install tinycc
+    python -m pip install "sasmodels[tinycc]"
 
-If Microsoft Visual C++ is available (because VCINSTALLDIR is
-defined in the environment), then that will be used instead.
+If TinyCC is not installed and Microsoft Visual C++ is available (because
+VCINSTALLDIR is defined in the environment), then Microsoft Visual C++ will
+be used instead.
 Microsoft Visual C++ for Python is available from Microsoft:
 
     `<http://www.microsoft.com/en-us/download/details.aspx?id=44266>`_
@@ -26,7 +26,7 @@ difficulties on some systems, and may or may not work for you.
 You can control which compiler to use by setting SAS_COMPILER in the
 environment:
 
-  - tinycc (Windows): use the TinyCC compiler shipped with SasView
+  - tinycc (Windows): use TinyCC from the optional tccbox package
   - msvc (Windows): use the Microsoft Visual C++ compiler
   - mingw (Windows): use the MinGW GNU cc compiler
   - unix (Linux): use the system cc compiler.
@@ -168,6 +168,11 @@ elif COMPILER == "msvc":
         return CC + ["/Tp%s"%source] + LN + ["/OUT:%s"%output]
 elif COMPILER == "tinycc":
     # TinyCC compiler.
+    if tccbox is None:
+        raise RuntimeError(
+            "SAS_COMPILER=tinycc requires the optional tccbox package. "
+            "Install it with: python -m pip install 'sasmodels[tinycc]'"
+        )
     CC = [
         tccbox.tcc_bin_path(),
         "-nostdinc",


### PR DESCRIPTION
Trying to fix https://github.com/conda-forge/sasmodels-feedstock/pull/19

From what I understand tccbox is only an optional dep for windows codepath? This PR exposes it through the Windows-only tinycc extra, and update CI to validate the resulting wheel metadata.